### PR TITLE
Add file Header for ELPA

### DIFF
--- a/src/rtags.el
+++ b/src/rtags.el
@@ -1,3 +1,30 @@
+;;; rtags.el --- A front-end for rtags
+
+;; Copyright (C) 2011-2014  Jan Erik Hanssen and Anders Bakken
+
+;; Author: Jan Erik Hanssen
+;;         Anders Bakken <agbakken@gmail.com>
+;; URL: https://github.com/Andersbakken/rtags
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;; Code:
+
 (defgroup rtags nil
   "Minor mode for rtags."
   :group 'tools
@@ -2423,3 +2450,5 @@ should use `irony-get-completion-point-anywhere'."
       (message "rtags process (rdm) stopped..."))))
 
 (provide 'rtags)
+
+;;; rtags.el ends here


### PR DESCRIPTION
Hi, I plan to add `rtags.el` to [MELPA](http://melpa.milkbox.net/).  This commit make `rtags.el` installable with `package.el`.  For information about this fix, See [Library-Headers](http://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html).
