### PR TITLE
Add autoload markers

### DIFF
--- a/src/rtags.el
+++ b/src/rtags.el
@@ -103,6 +103,7 @@
       (kill-buffer name))
   (generate-new-buffer name))
 
+;;;###autoload
 (defun rtags-bury-or-delete ()
   (interactive)
   (if (> (length (window-list)) 1)
@@ -160,7 +161,10 @@
     (setq rtags-buffer-bookmarks (- rtags-buffer-bookmarks 1)))
   )
 
+;;;###autoload
 (defun rtags-next-match () (interactive) (rtags-next-prev-match t))
+
+;;;###autoload
 (defun rtags-previous-match () (interactive) (rtags-next-prev-match nil))
 
 (defun rtags-next-prev-suitable-match (next)
@@ -201,7 +205,10 @@
             (rtags-select)))))
   )
 
+;;;###autoload
 (defun rtags-next-diag () (interactive) (rtags-next-prev-diag t))
+
+;;;###autoload
 (defun rtags-previous-diag () (interactive) (rtags-next-prev-diag nil))
 
 (defun rtags-next-prev-diag (next)
@@ -314,6 +321,7 @@
     )
   )
 
+;;;###autoload
 (defun rtags-index-js-file ()
   (interactive)
   (if (buffer-file-name)
@@ -339,6 +347,7 @@
     (buffer-string))
   )
 
+;;;###autoload
 (defun rtags-preprocess-file (&optional buffer)
   (interactive)
   (unless buffer (setq buffer (current-buffer)))
@@ -376,6 +385,7 @@
       (display-buffer preprocess-buffer))
     ))
 
+;;;###autoload
 (defun rtags-reparse-file (&optional buffer)
   (interactive)
   (let ((file (buffer-file-name buffer)))
@@ -387,6 +397,7 @@
 
 ;; /home/abakken/dev (loaded) <=
 
+;;;###autoload
 (defun rtags-set-current-project ()
   (interactive)
   (let ((projects nil)
@@ -465,10 +476,12 @@
                      (if verbose "--cursorinfo-include-references"))
       (buffer-string))))
 
+;;;###autoload
 (defun rtags-print-cursorinfo (&optional verbose)
   (interactive "P")
   (message "%s" (rtags-cursorinfo nil verbose)))
 
+;;;###autoload
 (defun rtags-print-dependencies (&optional buffer)
   (interactive)
   (let ((dep-buffer (rtags-get-buffer))
@@ -478,6 +491,7 @@
     (rtags-call-rc :path fn "--dependencies" fn)
     (rtags-start-mode nil t)))
 
+;;;###autoload
 (defun rtags-print-enum-value-at-point (&optional location)
   (interactive)
   (let ((info (rtags-cursorinfo location)))
@@ -523,6 +537,7 @@
               (+ pos carriagereturns))
           (+ (1- (point)) carriagereturns))))))
 
+;;;###autoload
 (defun rtags-goto-offset (pos)
   (interactive "NOffset: ")
   (if (rtags-buffer-is-multibyte)
@@ -631,6 +646,7 @@
     )
   )
 
+;;;###autoload
 (defun rtags-remove-completion-buffer ()
   (interactive)
   (kill-buffer (current-buffer))
@@ -672,6 +688,7 @@
     )
   )
 
+;;;###autoload
 (defun rtags-location-stack-jump (by)
   (interactive)
   (let ((instack (nth rtags-location-stack-index rtags-location-stack))
@@ -798,6 +815,7 @@ return t if rtags is allowed to modify this file"
   :group 'rtags
   :type 'boolean)
 
+;;;###autoload
 (defun rtags-enable-standard-keybindings (&optional map prefix)
   (interactive)
   (unless map
@@ -836,29 +854,35 @@ return t if rtags is allowed to modify this file"
     (add-hook 'find-file-hook 'rtags-index-js-file)
   (remove-hook 'find-file-hook 'rtags-index-js-file))
 
+;;;###autoload
 (defun rtags-print-current-location ()
   (interactive)
   (message (rtags-current-location)))
 
+;;;###autoload
 (defun rtags-quit-rdm () (interactive)
   (call-process (rtags-executable-find "rc") nil nil nil "--quit-rdm"))
 
+;;;###autoload
 (defun rtags-switch-to-completion-buffer () (interactive)
   (let ((buf (get-buffer "*RTags Completions*")))
     (if buf
         (switch-to-buffer-other-window buf)))
   )
 
+;;;###autoload
 (defun rtags-location-stack-forward ()
   (interactive)
   (rtags-location-stack-jump -1)
   )
 
+;;;###autoload
 (defun rtags-location-stack-back ()
   (interactive)
   (rtags-location-stack-jump 1)
   )
 
+;;;###autoload
 (defun rtags-location-stack-reset ()
   (interactive)
   (setq rtags-location-stack nil)
@@ -885,6 +909,8 @@ return t if rtags is allowed to modify this file"
   )
 
 ;; (defalias 'rtags-find-symbol-at-point 'rtags-follow-symbol-at-point)
+
+;;;###autoload
 (defun rtags-find-symbol-at-point (&optional prefix)
   "Find the natural target for the symbol under the cursor and moves to that location.
 For references this means to jump to the definition/declaration of the referenced symbol (it jumps to the definition if it is indexed).
@@ -898,6 +924,7 @@ If called with a prefix restrict to current buffer"
     )
   )
 
+;;;###autoload
 (defun rtags-find-references-at-point (&optional prefix)
   "Find all references to the symbol under the cursor
 If there's exactly one result jump directly to it.
@@ -914,6 +941,7 @@ References to references will be treated as references to the referenced symbol"
     )
   )
 
+;;;###autoload
 (defun rtags-find-virtuals-at-point (&optional prefix)
   "List all reimplentations of function under cursor. This includes both declarations and definitions"
   (interactive "P")
@@ -927,6 +955,7 @@ References to references will be treated as references to the referenced symbol"
     )
   )
 
+;;;###autoload
 (defun rtags-find-all-references-at-point (&optional prefix)
   (interactive "P")
   (rtags-save-location)
@@ -939,6 +968,7 @@ References to references will be treated as references to the referenced symbol"
     )
   )
 
+;;;###autoload
 (defun rtags-guess-function-at-point()
   (interactive)
   (rtags-save-location)
@@ -963,6 +993,7 @@ References to references will be treated as references to the referenced symbol"
           (forward-char))
         (buffer-substring-no-properties start (point))))))
 
+;;;###autoload
 (defun rtags-rename-symbol ()
   (interactive)
   (save-some-buffers) ;; it all kinda falls apart when buffers are unsaved
@@ -1026,18 +1057,22 @@ References to references will be treated as references to the referenced symbol"
     (message (format "Opened %d new files and made %d modifications" filesopened modifications)))
   )
 
+;;;###autoload
 (defun rtags-find-symbol (&optional prefix)
   (interactive "P")
   (rtags-find-symbols-by-name-internal "Find rsymbol" nil prefix))
 
+;;;###autoload
 (defun rtags-find-references (&optional prefix)
   (interactive "P")
   (rtags-find-symbols-by-name-internal "Find rreferences" t prefix))
 
+;;;###autoload
 (defun rtags-find-symbol-current-file ()
   (interactive)
   (rtags-find-symbol t))
 
+;;;###autoload
 (defun rtags-find-references-current-file ()
   (interactive)
   (rtags-find-references t))
@@ -1050,12 +1085,14 @@ References to references will be treated as references to the referenced symbol"
                       buffer-file-name))
           "[^/]*/?$"))
 
+;;;###autoload
 (defun rtags-find-symbol-current-dir ()
   (interactive)
   (setq rtags-path-filter-regex t)
   (rtags-find-symbols-by-name-internal "Find rsymbol" nil (rtags-dir-filter))
   (setq rtags-path-filter-regex nil))
 
+;;;###autoload
 (defun rtags-find-references-current-dir ()
   (interactive)
   (setq rtags-path-filter-regex t)
@@ -1138,6 +1175,7 @@ References to references will be treated as references to the referenced symbol"
     (rtags-post-expand))
   )
 
+;;;###autoload
 (defun rtags-rdm-completion-enabled ()
   (interactive)
   (with-temp-buffer
@@ -1147,6 +1185,7 @@ References to references will be treated as references to the referenced symbol"
         (looking-at "Can't seem to connect to server")))
   )
 
+;;;###autoload
 (defun rtags-expand ()
   (interactive)
   (if (and rtags-completion (or (eq rtags-completion-mode 'rtags-complete-with-dabbrev-and-autocomplete)
@@ -1163,6 +1202,7 @@ References to references will be treated as references to the referenced symbol"
        (string= (buffer-substring-no-properties (point-at-bol) (+ (point-at-bol) rtags-completion-cache-column))
                 rtags-completion-cache-line-contents)))
 
+;;;###autoload
 (defun rtags-init-completion-stream ()
   (interactive)
   (if (or (not rtags-completion-stream-process)
@@ -1180,6 +1220,7 @@ References to references will be treated as references to the referenced symbol"
         (set-process-filter rtags-completion-stream-process (function rtags-completion-stream-process-filter))))
   t)
 
+;;;###autoload
 (defun rtags-prepare-completions ()
   (interactive)
   ;;(message "prepare completion")
@@ -1213,6 +1254,8 @@ References to references will be treated as references to the referenced symbol"
   )
 
 (defvar rtags-diagnostics-process nil)
+
+;;;###autoload
 (defun rtags-apply-fixit-at-point ()
   (interactive)
   (let ((line (buffer-substring-no-properties (point-at-bol) (point-at-eol))))
@@ -1245,6 +1288,7 @@ References to references will be treated as references to the referenced symbol"
       (setq errorlist (cdr errorlist)))
     (puthash filename nil rtags-overlays)))
 
+;;;###autoload
 (defun rtags-clear-diagnostics-overlays()
   (interactive)
   (if (buffer-file-name)
@@ -1376,6 +1420,7 @@ References to references will be treated as references to the referenced symbol"
     )
   )
 
+;;;###autoload
 (defun rtags-is-running ()
   (interactive)
   (with-temp-buffer
@@ -1422,6 +1467,7 @@ References to references will be treated as references to the referenced symbol"
 
 (defvar rtags-highlighted-overlay nil)
 
+;;;###autoload
 (defun rtags-cycle-overlays-on-screen ()
   (interactive)
   (let* ((overlays (rtags-overlays-on-screen))
@@ -1448,6 +1494,7 @@ References to references will be treated as references to the referenced symbol"
           (if insert (insert insert)))))
   )
 
+;;;###autoload
 (defun rtags-fix-fixit-at-point ()
   (interactive)
   (let ((current-overlays (overlays-at (point))))
@@ -1512,6 +1559,8 @@ References to references will be treated as references to the referenced symbol"
   )
 
 (defvar rtags-completion-cache-timer nil)
+
+;;;###autoload
 (defun rtags-restart-completion-cache-timer ()
   (interactive)
   (if rtags-completion-cache-timer
@@ -1597,10 +1646,14 @@ should use `irony-get-completion-point-anywhere'."
 ;;     (allow-dups)
 ;;     (cache))
 
+;;;###autoload
 (defun rtags-ac-post-command-hook () (interactive) (if auto-complete-mode (ac-handle-post-command)))
+;;;###autoload
 (defun rtags-ac-pre-command-hook () (interactive) (if auto-complete-mode (ac-handle-pre-command)))
+;;;###autoload
 (defun rtags-ac-after-save-hook () (interactive) (if auto-complete-mode (ac-clear-variables-after-save)))
 
+;;;###autoload
 (defun rtags-ac-find-file-hook ()
   (interactive)
   (when (and (or (eq major-mode 'c++-mode)
@@ -1617,6 +1670,7 @@ should use `irony-get-completion-point-anywhere'."
     )
   t)
 
+;;;###autoload
 (defun rtags-update-completion-mode ()
   (interactive)
   (if (and rtags-completion-stream-process (eq (process-status rtags-completion-stream-process) 'run))
@@ -1657,6 +1711,8 @@ should use `irony-get-completion-point-anywhere'."
   )
 
 (defvar rtags-last-update-current-project-buffer nil)
+
+;;;###autoload
 (defun rtags-update-current-project ()
   (interactive)
   (condition-case nil
@@ -1675,6 +1731,8 @@ should use `irony-get-completion-point-anywhere'."
   )
 
 (defvar rtags-tracking-timer nil)
+
+;;;###autoload
 (defun rtags-restart-tracking-timer()
   (interactive)
   (if rtags-tracking-timer
@@ -1692,6 +1750,7 @@ should use `irony-get-completion-point-anywhere'."
                 (setq rtags-tracking-timer nil)))))
   )
 
+;;;###autoload
 (defun rtags-post-command-hook ()
   (interactive)
   (when rtags-enabled
@@ -1706,6 +1765,7 @@ should use `irony-get-completion-point-anywhere'."
 (add-hook 'post-command-hook (function rtags-post-command-hook))
 ;; (remove-hook 'post-command-hook (function rtags-post-command-hook))
 
+;;;###autoload
 (defun rtags-stop-diagnostics ()
   (interactive)
   (if (and rtags-diagnostics-process (not (eq (process-status rtags-diagnostics-process) 'exit)))
@@ -1713,6 +1773,7 @@ should use `irony-get-completion-point-anywhere'."
   (if (get-buffer "*RTags Diagnostics*")
       (kill-buffer "*RTags Diagnostics*")))
 
+;;;###autoload
 (defun rtags-clear-diagnostics ()
   (interactive)
   (when (get-buffer "*RTags Diagnostics*")
@@ -1795,6 +1856,7 @@ should use `irony-get-completion-point-anywhere'."
     )
   )
 
+;;;###autoload
 (defun rtags-diagnostics (&optional restart nodirty)
   (interactive "P")
   (if restart
@@ -1902,6 +1964,7 @@ should use `irony-get-completion-point-anywhere'."
     )
   )
 
+;;;###autoload
 (defun rtags-standard-save-hook ()
   (interactive)
   (if (and (get-buffer "*RTags Diagnostics*") (rtags-is-indexed))
@@ -1941,6 +2004,7 @@ should use `irony-get-completion-point-anywhere'."
   (run-hooks 'rtags-taglist-mode-hook)
   )
 
+;;;###autoload
 (defun rtags-close-taglist ()
   (interactive)
   (unless rtags-taglist-protected
@@ -1978,6 +2042,7 @@ should use `irony-get-completion-point-anywhere'."
     max)
   )
 
+;;;###autoload
 (defun rtags-taglist ()
   (interactive)
   (rtags-save-location)
@@ -2028,6 +2093,7 @@ should use `irony-get-completion-point-anywhere'."
     )
   )
 
+;;;###autoload
 (defun rtags-select (&optional other-window remove show)
   (interactive "P")
   (let* ((line (line-number-at-pos))
@@ -2051,19 +2117,23 @@ should use `irony-get-completion-point-anywhere'."
     )
   )
 
+;;;###autoload
 (defun rtags-select-other-window (&optional not-other-window)
   (interactive "P")
   (rtags-select (not not-other-window)))
 
+;;;###autoload
 (defun rtags-show-in-other-window ()
   (interactive)
   ;; (message "About to show")
   (rtags-select t nil t))
 
+;;;###autoload
 (defun rtags-select-and-remove-rtags-buffer ()
   (interactive)
   (rtags-select t t))
 
+;;;###autoload
 (defun rtags-imenu ()
   (interactive)
   (rtags-save-location)
@@ -2087,6 +2157,8 @@ should use `irony-get-completion-point-anywhere'."
   )
 
 (defvar rtags-find-file-history nil)
+
+;;;###autoload
 (defun rtags-find-file (&optional prefix tagname)
   (interactive "P")
   (rtags-save-location)
@@ -2141,11 +2213,13 @@ should use `irony-get-completion-point-anywhere'."
     )
   )
 
+;;;###autoload
 (defun rtags-show-rtags-buffer ()
   (interactive)
   (if (get-buffer rtags-buffer-name)
       (display-buffer rtags-buffer-name)))
 
+;;;###autoload
 (defun rtags-fixit (&optional ediff buffer)
   (interactive "P")
   (save-some-buffers)
@@ -2215,6 +2289,8 @@ should use `irony-get-completion-point-anywhere'."
           (cons start end)))))
 
 (defvar rtags-other-window-window nil)
+
+;;;###autoload
 (defun rtags-remove-other-window ()
   (interactive)
   (let ((ret ""))
@@ -2249,6 +2325,8 @@ should use `irony-get-completion-point-anywhere'."
   :type 'function)
 
 (defcustom rtags-other-window-window-size-percentage 30 "Percentage size of other buffer" :group 'rtags :type 'integer)
+
+;;;###autoload
 (defun rtags-show-target-in-other-window ()
   (interactive)
   (let ((target (rtags-target)))


### PR DESCRIPTION
That way no need to `(require 'rtags)` anymore when using it thought package (MELPA for example).
