### PR TITLE
Fix weird unstandard parenthesis style

### DIFF
--- a/src/rtags.el
+++ b/src/rtags.el
@@ -127,8 +127,7 @@
   (setq mode-name "rtags")
   (use-local-map rtags-mode-map)
   (run-hooks 'rtags-mode-hook)
-  (goto-char (point-min))
-  )
+  (goto-char (point-min)))
 
 (defun rtags-start-mode (bookmarks readonly)
   (rtags-reset-bookmarks)
@@ -149,16 +148,14 @@
                     (setq rtags-buffer-bookmarks (+ rtags-buffer-bookmarks 1))
                     (bookmark-set (format "R_%d" rtags-buffer-bookmarks))
                     (set-buffer buf)))))
-          (forward-line))
-        ))
+          (forward-line))))
   (setq buffer-read-only readonly)
   (rtags-mode))
 
 (defun rtags-reset-bookmarks ()
   (while (> rtags-buffer-bookmarks 0)
     (bookmark-delete (format "R_%d" rtags-buffer-bookmarks))
-    (setq rtags-buffer-bookmarks (- rtags-buffer-bookmarks 1)))
-  )
+    (setq rtags-buffer-bookmarks (- rtags-buffer-bookmarks 1))))
 
 (defun rtags-next-match () (interactive) (rtags-next-prev-match t))
 (defun rtags-previous-match () (interactive) (rtags-next-prev-match nil))
@@ -173,8 +170,7 @@
       (when next
         (goto-char (point-min))
         (beginning-of-line)))
-    (point))
-  )
+    (point)))
 
 (defun rtags-next-prev-match (next)
   (if (get-buffer rtags-buffer-name)
@@ -198,8 +194,7 @@
                  (goto-char (rtags-next-prev-suitable-match next))))
           (beginning-of-line)
           (if win (rtags-select-other-window)
-            (rtags-select)))))
-  )
+            (rtags-select))))))
 
 (defun rtags-next-diag () (interactive) (rtags-next-prev-diag t))
 (defun rtags-previous-diag () (interactive) (rtags-next-prev-diag nil))
@@ -298,8 +293,7 @@
                 (progn
                   (set-process-query-on-exit-flag proc nil)
                   (set-process-filter proc (car async))
-                  (set-process-sentinel proc (cdr async))
-                  )
+                  (set-process-sentinel proc (cdr async)))
               (progn
                 (goto-char (point-min))
                 (cond ((looking-at "Can't seem to connect to server")
@@ -310,9 +304,7 @@
                        (erase-buffer)
                        (message "Project loading..."))
                       (t nil)))))
-          (or async (> (point-max) (point-min))))))
-    )
-  )
+          (or async (> (point-max) (point-min))))))))
 
 (defun rtags-index-js-file ()
   (interactive)
@@ -330,14 +322,12 @@
   (use-local-map rtags-diagnostics-mode-map)
   (if (buffer-file-name)
       (error "Set buffer with file %s read only " (buffer-file-name)))
-  (setq buffer-read-only t)
-  )
+  (setq buffer-read-only t))
 
 (defun rtags-builds (&optional file)
   (with-temp-buffer
     (rtags-call-rc :path file "--builds" file)
-    (buffer-string))
-  )
+    (buffer-string)))
 
 (defun rtags-preprocess-file (&optional buffer)
   (interactive)
@@ -373,17 +363,14 @@
                     (goto-char (point-min))
                     (narrow-to-region (point-at-bol (+ start 1)) (point-at-bol (+ end 1)))))))
         (rtags-preprocess-mode))
-      (display-buffer preprocess-buffer))
-    ))
+      (display-buffer preprocess-buffer))))
 
 (defun rtags-reparse-file (&optional buffer)
   (interactive)
   (let ((file (buffer-file-name buffer)))
     (with-temp-buffer
       (rtags-call-rc :path file "-V" file))
-    (message (format "Dirtied %s" file))
-    )
-  )
+    (message (format "Dirtied %s" file))))
 
 ;; /home/abakken/dev (loaded) <=
 
@@ -403,15 +390,12 @@
                 (setq current name))
             (if (string-match "^\\([^ ]+\\)[^<]*$" line)
                 (setq projects (add-to-list 'projects (match-string 1 line))))))
-        (forward-line))
-      )
+        (forward-line)))
     (setq project (ido-completing-read
                    (format "RTags select project (current is %s): " current)
                    projects))
     (if project
-        (with-temp-buffer (rtags-call-rc :output nil :path t "-w" project)))
-    )
-  )
+        (with-temp-buffer (rtags-call-rc :output nil :path t "-w" project)))))
 
 (defun rtags-find-ancestor-file (pattern)
   "Find a file named \a file in as shallow a path as possible,
@@ -502,8 +486,7 @@
 (defun rtags-carriage-returns ()
   (if (rtags-buffer-is-dos)
       (1- (line-number-at-pos))
-    0)
-  )
+    0))
 
 (defun rtags-offset (&optional p)
   (let (carriagereturns)
@@ -547,10 +530,7 @@
         (goto-char (point-max))
         (setq buffer-read-only nil)
         (insert "**********************************\n" log "\n")
-        (setq buffer-read-only t)
-        )
-    )
-  )
+        (setq buffer-read-only t))))
 
 (defvar rtags-symbol-history nil)
 
@@ -566,9 +546,7 @@
     (let ((buf (get-buffer file-or-buffer)))
       (cond ((not buf) (message "No buffer named %s" file-or-buffer))
             (other-window (switch-to-buffer-other-window file-or-buffer))
-            (t (switch-to-buffer file-or-buffer))))
-    )
-  )
+            (t (switch-to-buffer file-or-buffer))))))
 
 (defun rtags-goto-location (location &optional nobookmark other-window)
   "Go to a location passed in. It can be either: file,12 or file:13:14 or plain file"
@@ -601,9 +579,7 @@
            (if (string-match "^ +\\(.*\\)$" location)
                (setq location (match-string 1 location)))
            (rtags-find-file-or-buffer location other-window)))
-    (unless nobookmark (rtags-location-stack-push))
-    )
-  )
+    (unless nobookmark (rtags-location-stack-push))))
 
 (defvar rtags-async-filter-and-sentinel (cons 'rtags-async-rc-filter 'rtags-async-rc-sentinel))
 
@@ -627,9 +603,7 @@
           (setq references rtags-async-filter-and-sentinel))
       (rtags-call-rc :path path switch tagname :path-filter filter "-l")
       (rtags-reset-bookmarks)
-      (rtags-handle-completion-buffer))
-    )
-  )
+      (rtags-handle-completion-buffer))))
 
 (defun rtags-remove-completion-buffer ()
   (interactive)
@@ -660,17 +634,11 @@
     (while (> rtags-location-stack-index 0)
       (progn
         (setq rtags-location-stack-index (- rtags-location-stack-index 1))
-        (pop rtags-location-stack)
-        )
-      )
+        (pop rtags-location-stack)))
     (unless (string= bm (nth 0 rtags-location-stack))
       (push bm rtags-location-stack)
       (if (> (length rtags-location-stack) rtags-max-bookmark-count)
-          (nbutlast rtags-location-stack (- (length rtags-location-stack) rtags-max-bookmark-count))
-        )
-      )
-    )
-  )
+          (nbutlast rtags-location-stack (- (length rtags-location-stack) rtags-max-bookmark-count))))))
 
 (defun rtags-location-stack-jump (by)
   (interactive)
@@ -682,13 +650,7 @@
         (if (and (>= target 0) (< target (length rtags-location-stack)))
             (progn
               (setq rtags-location-stack-index target)
-              (rtags-goto-location (nth rtags-location-stack-index rtags-location-stack) t)
-              )
-          )
-        )
-      )
-    )
-  )
+              (rtags-goto-location (nth rtags-location-stack-index rtags-location-stack) t)))))))
 
 ;; **************************** API *********************************
 
@@ -829,8 +791,7 @@ return t if rtags is allowed to modify this file"
   (define-key map (concat prefix "x") (function rtags-fix-fixit-at-point))
   (define-key map (concat prefix "B") (function rtags-show-rtags-buffer))
   (define-key map (concat prefix "I") (function rtags-imenu))
-  (define-key map (concat prefix "T") (function rtags-taglist))
-  )
+  (define-key map (concat prefix "T") (function rtags-taglist)))
 
 (if rtags-index-js-files
     (add-hook 'find-file-hook 'rtags-index-js-file)
@@ -846,24 +807,20 @@ return t if rtags is allowed to modify this file"
 (defun rtags-switch-to-completion-buffer () (interactive)
   (let ((buf (get-buffer "*RTags Completions*")))
     (if buf
-        (switch-to-buffer-other-window buf)))
-  )
+        (switch-to-buffer-other-window buf))))
 
 (defun rtags-location-stack-forward ()
   (interactive)
-  (rtags-location-stack-jump -1)
-  )
+  (rtags-location-stack-jump -1))
 
 (defun rtags-location-stack-back ()
   (interactive)
-  (rtags-location-stack-jump 1)
-  )
+  (rtags-location-stack-jump 1))
 
 (defun rtags-location-stack-reset ()
   (interactive)
   (setq rtags-location-stack nil)
-  (setq rtags-location-stack-index 0)
-  )
+  (setq rtags-location-stack-index 0))
 
 (defun rtags-target (&optional filter)
   (let ((path (buffer-file-name))
@@ -878,11 +835,7 @@ return t if rtags is allowed to modify this file"
                 ((or (string= (buffer-string) "Not indexed\n")
                      (string= (buffer-string) "Can't seem to connect to server\n"))
                  (setq rtags-last-request-not-indexed t) nil)
-                (t (buffer-substring-no-properties (point-min) (- (point-max) 1))))
-          )
-      )
-    )
-  )
+                (t (buffer-substring-no-properties (point-min) (- (point-max) 1))))))))
 
 ;; (defalias 'rtags-find-symbol-at-point 'rtags-follow-symbol-at-point)
 (defun rtags-find-symbol-at-point (&optional prefix)
@@ -894,9 +847,7 @@ If called with a prefix restrict to current buffer"
   (rtags-save-location)
   (let ((target (rtags-target prefix)))
     (if target
-        (rtags-goto-location target))
-    )
-  )
+        (rtags-goto-location target))))
 
 (defun rtags-find-references-at-point (&optional prefix)
   "Find all references to the symbol under the cursor
@@ -910,9 +861,7 @@ References to references will be treated as references to the referenced symbol"
         (context (rtags-current-symbol t)))
     (with-current-buffer (rtags-get-buffer)
       (rtags-call-rc :path fn :context context :path-filter prefix "-r" arg "-l")
-      (rtags-handle-completion-buffer))
-    )
-  )
+      (rtags-handle-completion-buffer))))
 
 (defun rtags-find-virtuals-at-point (&optional prefix)
   "List all reimplentations of function under cursor. This includes both declarations and definitions"
@@ -923,9 +872,7 @@ References to references will be treated as references to the referenced symbol"
         (context (rtags-current-symbol t)))
     (with-current-buffer (rtags-get-buffer)
       (rtags-call-rc :path fn :context context :path-filter prefix "-r" arg "-k" "-l")
-      (rtags-handle-completion-buffer))
-    )
-  )
+      (rtags-handle-completion-buffer))))
 
 (defun rtags-find-all-references-at-point (&optional prefix)
   (interactive "P")
@@ -935,9 +882,7 @@ References to references will be treated as references to the referenced symbol"
         (context (rtags-current-symbol t)))
     (with-current-buffer (rtags-get-buffer)
       (rtags-call-rc :path fn :context context :path-filter prefix "-r" arg "-e" "-l")
-      (rtags-handle-completion-buffer))
-    )
-  )
+      (rtags-handle-completion-buffer))))
 
 (defun rtags-guess-function-at-point()
   (interactive)
@@ -948,8 +893,7 @@ References to references will be treated as references to the referenced symbol"
     (if token
         (with-current-buffer (rtags-get-buffer)
           (rtags-call-rc :path fn "--declaration-only" "-F" token)
-          (rtags-handle-completion-buffer t))))
-  )
+          (rtags-handle-completion-buffer t)))))
 
 (defun rtags-current-token ()
   (save-excursion
@@ -1015,16 +959,8 @@ References to references will be treated as references to the referenced symbol"
                       ;;          (buffer-substring-no-properties (point) (+ (point) len)) replacewith (point) (car value))
                       (delete-char len)
                       (insert replacewith)
-                      (basic-save-buffer)
-                      ))
-                  )
-                )
-              )
-            )
-        )
-      )
-    (message (format "Opened %d new files and made %d modifications" filesopened modifications)))
-  )
+                      (basic-save-buffer)))))))))
+    (message (format "Opened %d new files and made %d modifications" filesopened modifications))))
 
 (defun rtags-find-symbol (&optional prefix)
   (interactive "P")
@@ -1071,8 +1007,7 @@ References to references will be treated as references to the referenced symbol"
       (if (looking-at "[A-Za-z0-9_]")
           (c-beginning-of-current-token)
         (forward-char))
-      (- (point) (point-at-bol))))
-  )
+      (- (point) (point-at-bol)))))
 
 (defun rtags-post-expand ()
   (save-excursion
@@ -1135,8 +1070,7 @@ References to references will be treated as references to the referenced symbol"
          (setq dabbrev-search-these-buffers-only was-search)))))
   (when (not (string= rtags-completion-cache-file-name ""))
     (funcall rtags-expand-function)
-    (rtags-post-expand))
-  )
+    (rtags-post-expand)))
 
 (defun rtags-rdm-completion-enabled ()
   (interactive)
@@ -1144,16 +1078,14 @@ References to references will be treated as references to the referenced symbol"
     (rtags-call-rc "--code-completion-enabled" :noerror t)
     (goto-char (point-min))
     (or (looking-at "1")
-        (looking-at "Can't seem to connect to server")))
-  )
+        (looking-at "Can't seem to connect to server"))))
 
 (defun rtags-expand ()
   (interactive)
   (if (and rtags-completion (or (eq rtags-completion-mode 'rtags-complete-with-dabbrev-and-autocomplete)
                                 (eq rtags-completion-mode 'rtags-complete-with-dabbrev)))
       (rtags-expand-internal)
-    (funcall rtags-expand-function))
-  )
+    (funcall rtags-expand-function)))
 
 (defvar rtags-completion-stream-process nil)
 (defun rtags-completion-cache-is-valid ()
@@ -1207,10 +1139,7 @@ References to references will be treated as references to the referenced symbol"
               rtags-completion-cache-line-contents (buffer-substring-no-properties (point-at-bol) (+ (point-at-bol) column)))
         ;; (message "writing shit %s" header)
         (process-send-string rtags-completion-stream-process header)
-        (process-send-string rtags-completion-stream-process (buffer-substring-no-properties (point-min) (point-max))))
-      )
-    )
-  )
+        (process-send-string rtags-completion-stream-process (buffer-substring-no-properties (point-min) (point-max)))))))
 
 (defvar rtags-diagnostics-process nil)
 (defun rtags-apply-fixit-at-point ()
@@ -1248,8 +1177,7 @@ References to references will be treated as references to the referenced symbol"
 (defun rtags-clear-diagnostics-overlays()
   (interactive)
   (if (buffer-file-name)
-      (rtags-overlays-remove (buffer-file-name)))
-  )
+      (rtags-overlays-remove (buffer-file-name))))
 
 (defun rtags-really-find-buffer (fn)
   (setq fn (file-truename fn))
@@ -1312,8 +1240,7 @@ References to references will be treated as references to the referenced symbol"
                     (insert (format "%s:%d:%d: %s: %s\n" filename line column severity message)))
 
                   (setq errorlist (append errorlist (list overlay)))
-                  (puthash filename errorlist rtags-overlays))))))))
-  )
+                  (puthash filename errorlist rtags-overlays)))))))))
 
 (defun rtags-parse-overlay-node (node)
   (when (listp node)
@@ -1327,9 +1254,7 @@ References to references will be treated as references to the referenced symbol"
           (goto-char (point-min))
           (flush-lines (concat filename ":")))
         (dolist (it body)
-          (rtags-parse-overlay-error-node it filename))))
-    )
-  )
+          (rtags-parse-overlay-error-node it filename))))))
 
 (defvar rtags-last-index nil)
 (defvar rtags-last-total nil)
@@ -1364,17 +1289,11 @@ References to references will be treated as references to the referenced symbol"
                (setq body (cdr body)))
              (force-mode-line-update))
             ;;             (message "RTags: %s/%s (%s%%)" index total)))
-            (t (message "Unexpected root element %s" (car doc)))
-            )
-      )
-    )
-  )
+            (t (message "Unexpected root element %s" (car doc)))))))
 
 (defun rtags-check-overlay (overlay)
   (if (and (not (active-minibuffer-window)) (not cursor-in-echo-area))
-      (rtags-display-overlay overlay (point))
-    )
-  )
+      (rtags-display-overlay overlay (point))))
 
 (defun rtags-is-running ()
   (interactive)
@@ -1387,8 +1306,7 @@ References to references will be treated as references to the referenced symbol"
       (if rtags-display-current-error-as-tooltip
           (popup-tip msg :point point)) ;; :face 'rtags-warnline)) ;;(overlay-get overlay 'face)))
       (if rtags-display-current-error-as-message
-          (message (concat "RTags: " msg)))))
-  )
+          (message (concat "RTags: " msg))))))
 
 (defvar rtags-update-current-error-timer nil)
 
@@ -1396,8 +1314,7 @@ References to references will be treated as references to the referenced symbol"
   (let ((current-overlays (overlays-at (point))))
     (setq rtags-update-current-error-timer nil)
     (while (and current-overlays (not (rtags-check-overlay (car current-overlays))))
-      (setq current-overlays (cdr current-overlays))))
-  )
+      (setq current-overlays (cdr current-overlays)))))
 
 (defun rtags-update-current-error ()
   (if rtags-update-current-error-timer
@@ -1409,8 +1326,7 @@ References to references will be treated as references to the referenced symbol"
              (run-with-idle-timer
               rtags-error-timer-interval
               nil
-              (function rtags-display-current-error))))
-  )
+              (function rtags-display-current-error)))))
 
 (defun rtags-is-rtags-overlay (overlay) (and overlay (overlay-get overlay 'rtags-error-message)))
 
@@ -1431,8 +1347,7 @@ References to references will be treated as references to the referenced symbol"
                     (car overlays))))
     (when overlay
       (setq rtags-highlighted-overlay overlay)
-      (rtags-display-overlay overlay (overlay-start overlay))))
-  )
+      (rtags-display-overlay overlay (overlay-start overlay)))))
 
 (defun rtags-fix-fixit-overlay (overlay)
   (let ((msg (overlay-get overlay 'rtags-error-message))
@@ -1445,15 +1360,13 @@ References to references will be treated as references to the referenced symbol"
           (setq insert (match-string 1 msg))
           (rtags-goto-offset start)
           (delete-char (- end start))
-          (if insert (insert insert)))))
-  )
+          (if insert (insert insert))))))
 
 (defun rtags-fix-fixit-at-point ()
   (interactive)
   (let ((current-overlays (overlays-at (point))))
     (while (and current-overlays (not (rtags-fix-fixit-overlay (car current-overlays))))
-      (setq current-overlays (cdr current-overlays))))
-  )
+      (setq current-overlays (cdr current-overlays)))))
 
 (defvar rtags-completion-signatures (make-hash-table :test 'equal))
 (defvar rtags-completion-buffer-pending nil)
@@ -1501,15 +1414,7 @@ References to references will be treated as references to the referenced symbol"
                   (progn
                     (unless (= last (length output))
                       (setq rtags-completion-buffer-pending (substring output last)))
-                    (setq continue nil))
-                  )
-                )
-              )
-            )
-          )
-      )
-    )
-  )
+                    (setq continue nil))))))))))
 
 (defvar rtags-completion-cache-timer nil)
 (defun rtags-restart-completion-cache-timer ()
@@ -1520,16 +1425,14 @@ References to references will be treated as references to the referenced symbol"
         (and (or (eq major-mode 'c++-mode)
                  (eq major-mode 'c-mode))
              (not (eq rtags-completion-mode 'rtags-completion-disabled))
-             (run-with-idle-timer rtags-completion-timer-interval nil (function rtags-prepare-completions))))
-  )
+             (run-with-idle-timer rtags-completion-timer-interval nil (function rtags-prepare-completions)))))
 
 (defun rtags-ac-completions ()
   (if (get-buffer "*RTags Completions*")
       (with-current-buffer "*RTags Completions*"
         (unless (string= (buffer-substring-no-properties (1+ (point-min)) (1- (point-max)))
                          "Process RTags Completions Stream finished")
-          (split-string (buffer-string)))))
-  )
+          (split-string (buffer-string))))))
 
 
 ;; stolen from irony-mode ;; https://github.com/Sarcasm/irony-mode
@@ -1584,8 +1487,7 @@ should use `irony-get-completion-point-anywhere'."
 (defconst rtags-ac-completions-source
   '((candidates . rtags-ac-completions)
     (prefix . rtags-irony-get-completion-point)
-    (requires . 0))
-  )
+    (requires . 0)))
 
 ;; (defconst ac-source-irony
 ;;   '((candidates     . (irony-ac-candidates ac-point))
@@ -1613,8 +1515,7 @@ should use `irony-get-completion-point-anywhere'."
     (kill-local-variable 'after-save-hook)
     (add-hook 'post-command-hook (function rtags-ac-post-command-hook))
     (add-hook 'pre-command-hook (function rtags-ac-pre-command-hook))
-    (add-hook 'after-save-hook (function rtags-ac-after-save-hook))
-    )
+    (add-hook 'after-save-hook (function rtags-ac-after-save-hook)))
   t)
 
 (defun rtags-update-completion-mode ()
@@ -1633,8 +1534,7 @@ should use `irony-get-completion-point-anywhere'."
             (setq ac-sources (list ac-source-words-in-same-mode-buffers))))
     (progn
       (unless (eq rtags-completion-mode 'rtags-complete-with-dabbrev)
-        (add-hook 'find-file-hook 'rtags-ac-find-file-hook))))
-  )
+        (add-hook 'find-file-hook 'rtags-ac-find-file-hook)))))
 
 (defcustom rtags-completion-mode 'rtags-completion-disabled
   "What to do about completion with rtags"
@@ -1653,8 +1553,7 @@ should use `irony-get-completion-point-anywhere'."
             (setq value 'rtags-completion-disabled))
           (custom-set-default variable value)
           (rtags-update-completion-mode)
-          value)
-  )
+          value))
 
 (defvar rtags-last-update-current-project-buffer nil)
 (defun rtags-update-current-project ()
@@ -1671,8 +1570,7 @@ should use `irony-get-completion-point-anywhere'."
             (let ((mapped (if rtags-match-source-file-to-project (apply rtags-match-source-file-to-project (list path)))))
               (if (and mapped (length mapped)) (push (concat "--with-project=" mapped) arguments)))
             (apply #'start-process "rtags-update-current-project" nil rc arguments))))
-    (error (message "Got error in rtags-update-current-project")))
-  )
+    (error (message "Got error in rtags-update-current-project"))))
 
 (defvar rtags-tracking-timer nil)
 (defun rtags-restart-tracking-timer()
@@ -1689,8 +1587,7 @@ should use `irony-get-completion-point-anywhere'."
                     (rtags-show-in-other-window))
                 (if rtags-tracking-timer
                     (cancel-timer rtags-tracking-timer))
-                (setq rtags-tracking-timer nil)))))
-  )
+                (setq rtags-tracking-timer nil))))))
 
 (defun rtags-post-command-hook ()
   (interactive)
@@ -1700,8 +1597,7 @@ should use `irony-get-completion-point-anywhere'."
     (rtags-restart-completion-cache-timer)
     (rtags-restart-update-local-references-timer)
     (rtags-close-taglist)
-    (rtags-restart-tracking-timer))
-  )
+    (rtags-restart-tracking-timer)))
 
 (add-hook 'post-command-hook (function rtags-post-command-hook))
 ;; (remove-hook 'post-command-hook (function rtags-post-command-hook))
@@ -1723,10 +1619,7 @@ should use `irony-get-completion-point-anywhere'."
         (delete-char (- (point-max) (point-min)))
         (if (buffer-file-name)
             (error "Set buffer with file %s read only " (buffer-file-name)))
-        (setq buffer-read-only t))
-      )
-    )
-  )
+        (setq buffer-read-only t)))))
 
 (defun rtags-trim-whitespace (str)
   (while (string-match "\\`\n+\\|^\\s-+\\|\\s-+$\\|\n+\\'" str)
@@ -1761,9 +1654,7 @@ should use `irony-get-completion-point-anywhere'."
           (error "Set buffer with file %s read only " (buffer-file-name)))
       (setq buffer-read-only t)
       (when (> (length output) 0)
-        (setq rtags-pending-diagnostics output)))
-    )
-  )
+        (setq rtags-pending-diagnostics output)))))
 
 (defvar rtags-diagnostics-mode-map (make-sparse-keymap))
 (define-key rtags-diagnostics-mode-map (kbd "q") 'rtags-bury-or-delete)
@@ -1775,8 +1666,7 @@ should use `irony-get-completion-point-anywhere'."
   (use-local-map rtags-diagnostics-mode-map)
   (if (buffer-file-name)
       (error "Set buffer with file %s read only " (buffer-file-name)))
-  (setq buffer-read-only t)
-  )
+  (setq buffer-read-only t))
 
 (defun rtags-init-diagnostics-buffer-and-process (&optional nodirty)
   (let ((buf (get-buffer-create "*RTags Diagnostics*")))
@@ -1790,10 +1680,7 @@ should use `irony-get-completion-point-anywhere'."
         (let ((process-connection-type nil)) ;; use a pipe
           (setq rtags-diagnostics-process (start-process "RTags Diagnostics" buf (rtags-executable-find "rc") "-m"))
           (set-process-filter rtags-diagnostics-process (function rtags-diagnostics-process-filter))
-          (rtags-clear-diagnostics))
-      )
-    )
-  )
+          (rtags-clear-diagnostics)))))
 
 (defun rtags-diagnostics (&optional restart nodirty)
   (interactive "P")
@@ -1801,8 +1688,7 @@ should use `irony-get-completion-point-anywhere'."
       (rtags-stop-diagnostics))
   (rtags-init-diagnostics-buffer-and-process)
   (switch-to-buffer-other-window "*RTags Diagnostics*")
-  (other-window 1)
-  )
+  (other-window 1))
 
 (defvar rtags-indexed nil)
 (defvar rtags-file-managed nil)
@@ -1815,8 +1701,7 @@ should use `irony-get-completion-point-anywhere'."
       (goto-char (point-min))
       (cond ((looking-at "1") 'rtags-indexed)
             ((looking-at "2") 'rtags-file-managed)
-            (t nil))))
-  )
+            (t nil)))))
 
 (defun rtags-is-indexed (&optional buffer)
   (equal (rtags-buffer-status buffer) 'rtags-indexed))
@@ -1844,12 +1729,7 @@ should use `irony-get-completion-point-anywhere'."
            (rtags-start-mode t nil)
            (setq buffer-read-only wasreadonly)
            (when (and rtags-jump-to-first-match (not noautojump))
-             (rtags-select-other-window)
-             )
-           )
-          )
-    )
-  )
+             (rtags-select-other-window))))))
 
 (defun rtags-is-definition (kind)
   (cond ((string= kind "0") nil)
@@ -1865,9 +1745,7 @@ should use `irony-get-completion-point-anywhere'."
 ;;         (rint (string-to-number r)))
 ;;     (cond ((< lint rint) -1)
 ;;           ((> lint rint) 1)
-;;           (t 0))
-;;     )
-;;   )
+;;           (t 0))))
 
 (defun rtags-async-rc-filter (process output)
   (let ((buf (process-buffer process))
@@ -1886,8 +1764,7 @@ should use `irony-get-completion-point-anywhere'."
       (when (and wasempty hasline)
         (when (buffer-file-name)
           (error "Set buffer with file %s read only " (buffer-file-name)))
-        (rtags-handle-completion-buffer nil t))))
-  )
+        (rtags-handle-completion-buffer nil t)))))
 
 (defun rtags-async-rc-sentinel (process state)
   (when (string= state "finished\n")
@@ -1898,9 +1775,7 @@ should use `irony-get-completion-point-anywhere'."
             (setq buffer-read-only nil)
             (flush-lines "^[ \t]*$" (point-min) (point-max) nil)
             (flush-lines "Process finished rc" (point-min) (point-max) nil)
-            (setq buffer-read-only wasreadonly)))))
-    )
-  )
+            (setq buffer-read-only wasreadonly)))))))
 
 (defun rtags-standard-save-hook ()
   (interactive)
@@ -1938,8 +1813,7 @@ should use `irony-get-completion-point-anywhere'."
 (define-derived-mode rtags-taglist-mode fundamental-mode
   (setq mode-name "rtags-taglist")
   (use-local-map rtags-mode-map)
-  (run-hooks 'rtags-taglist-mode-hook)
-  )
+  (run-hooks 'rtags-taglist-mode-hook))
 
 (defun rtags-close-taglist ()
   (interactive)
@@ -1953,12 +1827,7 @@ should use `irony-get-completion-point-anywhere'."
               (when (eq (window-buffer (car windows)) buf)
                 (delete-window (car windows))
                 (setq windows nil))
-              (setq windows (cdr windows)))
-            )
-        )
-      )
-    )
-  )
+              (setq windows (cdr windows))))))))
 
 ;; category (list (text . (location . linenumber)))
 (defun rtags-taglist-insert-category (category name)
@@ -1973,10 +1842,8 @@ should use `irony-get-completion-point-anywhere'."
                (len (length text)))
           (insert " " text "\n")
           (setq max (max len max)))
-        (setq category (cdr category)))
-      )
-    max)
-  )
+        (setq category (cdr category))))
+    max))
 
 (defun rtags-taglist ()
   (interactive)
@@ -2003,9 +1870,7 @@ should use `irony-get-completion-point-anywhere'."
                                      ((or (string= type "macro definition") (string= type "include directive")) 'macros)
                                      (t 'other))
                                (cons (concat text ":" linenum) (concat loc-start linenum loc-end))))))
-          (forward-line))
-        )
-      )
+          (forward-line))))
     (when (or functions classes variables enums macros other)
       (delete-other-windows)
       (let ((buf (rtags-get-buffer)) (max 0))
@@ -2022,11 +1887,7 @@ should use `irony-get-completion-point-anywhere'."
           (forward-line))
         (split-window-horizontally (min (/ (frame-width) 2) (+ 2 max)))
         (switch-to-buffer buf)
-        (rtags-taglist-mode)
-        )
-      )
-    )
-  )
+        (rtags-taglist-mode)))))
 
 (defun rtags-select (&optional other-window remove show)
   (interactive "P")
@@ -2047,9 +1908,7 @@ should use `irony-get-completion-point-anywhere'."
     (if remove
         (delete-window window)
       (if show
-          (select-window window)))
-    )
-  )
+          (select-window window)))))
 
 (defun rtags-select-other-window (&optional not-other-window)
   (interactive "P")
@@ -2083,8 +1942,7 @@ should use `irony-get-completion-point-anywhere'."
   (while (< (point-at-eol) (point-max))
     (goto-char (point-at-eol))
     (insert txt)
-    (forward-line))
-  )
+    (forward-line)))
 
 (defvar rtags-find-file-history nil)
 (defun rtags-find-file (&optional prefix tagname)
@@ -2135,11 +1993,7 @@ should use `irony-get-completion-point-anywhere'."
             (t (progn
                  (switch-to-buffer-other-window rtags-buffer-name)
                  (shrink-window-if-larger-than-buffer)
-                 (rtags-start-mode nil t)
-                 )))
-      )
-    )
-  )
+                 (rtags-start-mode nil t)))))))
 
 (defun rtags-show-rtags-buffer ()
   (interactive)
@@ -2177,16 +2031,12 @@ should use `irony-get-completion-point-anywhere'."
                       (delete-char (- end start)) ;; may be 0
                       (insert text))))))
           ;; (message (format "got something %d to %d => [%s]" start end text))))
-          (forward-line))
-        )
+          (forward-line)))
       (if tempbuf
           (let ((tempbufname (format "/tmp/rtags-fixit-%s" (file-name-nondirectory path))))
             (with-current-buffer tempbuf (write-file tempbufname))
             (kill-buffer tempbuf)
-            (ediff path tempbufname)))
-      )
-    )
-  )
+            (ediff path tempbufname))))))
 
 (defun rtags-current-symbol-name (&optional cursorinfo)
   (unless cursorinfo
@@ -2194,9 +2044,7 @@ should use `irony-get-completion-point-anywhere'."
   (let ((container (string-match "^Container:" cursorinfo))
         (symbolname (string-match "^SymbolName: \\(.*\\)$" cursorinfo)))
     (if (and symbolname (or (not container) (< symbolname container)))
-        (match-string 1 cursorinfo))
-    )
-  )
+        (match-string 1 cursorinfo))))
 
 (defun rtags-current-container-name (&optional cursorinfo)
   (unless cursorinfo
@@ -2283,25 +2131,21 @@ should use `irony-get-completion-point-anywhere'."
     (with-temp-buffer
       (if text
           (insert text))
-      (rtags-call-rc :path path :unsaved buffer "-x" (format "%s:%d:%d" path line column)))
-    )
-  )
+      (rtags-call-rc :path path :unsaved buffer "-x" (format "%s:%d:%d" path line column)))))
 
 (defvar rtags-local-references-overlays nil)
 (defun rtags-clear-local-references-overlays()
   (interactive)
   (while rtags-local-references-overlays
     (delete-overlay (car rtags-local-references-overlays))
-    (setq rtags-local-references-overlays (cdr rtags-local-references-overlays)))
-  )
+    (setq rtags-local-references-overlays (cdr rtags-local-references-overlays))))
 
 (defun rtags-offset-for-line-column (line col)
   (let (deactivate-mark)
     (save-excursion
       (goto-char (point-min))
       (forward-line (1- line))
-      (+ (point-at-bol) col -1)))
-  )
+      (+ (point-at-bol) col -1))))
 
 (defun rtags-range-visible (start end)
   (and (>= start (window-start))
@@ -2337,10 +2181,7 @@ should use `irony-get-completion-point-anywhere'."
                    (let ((overlay (make-overlay offset (+ offset symlen) nil t)))
                      (overlay-put overlay 'face 'rtags-local-reference)
                      (setq rtags-local-references-overlays (append rtags-local-references-overlays (list overlay))))))))
-        (setq lines (cdr lines)))
-      )
-    )
-  )
+        (setq lines (cdr lines))))))
 
 
 (defvar rtags-local-references-timer nil)
@@ -2356,9 +2197,7 @@ should use `irony-get-completion-point-anywhere'."
              (progn
                (rtags-clear-local-references-overlays)
                (run-with-idle-timer rtags-local-references-timer-interval
-                                    nil (function rtags-update-local-references))))
-        )
-  )
+                                    nil (function rtags-update-local-references))))))
 
 (defun rtags-toggle-file-suspended()
   (interactive)
@@ -2368,8 +2207,7 @@ should use `irony-get-completion-point-anywhere'."
           (rtags-call-rc :path buffer "-X" buffer)
           (if (> (point-max) (point-min))
               (message (buffer-substring-no-properties (point-min) (1- (point-max))))
-            (message (buffer-string))))))
-  )
+            (message (buffer-string)))))))
 
 (defun rtags-clear-suspended-files()
   (interactive)
@@ -2379,8 +2217,7 @@ should use `irony-get-completion-point-anywhere'."
           (rtags-call-rc :path buffer "-X" "clear")
           (if (> (point-max) (point-min))
               (message (buffer-substring-no-properties (point-min) (1- (point-max))))
-            (message (buffer-string))))))
-  )
+            (message (buffer-string)))))))
 
 (defun rtags-list-suspended-files()
   (interactive)
@@ -2390,8 +2227,7 @@ should use `irony-get-completion-point-anywhere'."
           (rtags-call-rc :path buffer "-X")
           (if (> (point-max) (point-min))
               (message (buffer-substring-no-properties (point-min) (1- (point-max))))
-            (message (buffer-string))))))
-  )
+            (message (buffer-string)))))))
 
 (defun rtags-dummy-includes-func()
   "Dummy function, returns rtags-rdm-includes."


### PR DESCRIPTION
Based on http://www.emacswiki.org/emacs/CodingStyle:

 _"Use the default indentation. Closing parenthesis shall never stand on their own."_
