### PR TITLE
Improve regular expressions to handle cases with :#:# in the code

### DIFF
--- a/src/rtags.el
+++ b/src/rtags.el
@@ -93,7 +93,7 @@
   :group 'rtags)
 
 (defvar rtags-font-lock-keywords
-  `((,"^\\(.*:[0-9]+:[0-9]+:\\)\\(.*\\)$"
+  `((,"^\\(.*?:[0-9]+:[0-9]+:\\)\\(.*\\)$"
      (1 font-lock-string-face)
      (2 font-lock-function-name-face))))
 
@@ -136,7 +136,7 @@
       (let ((buf (current-buffer)))
         (goto-char (point-min))
         (while (not (eobp))
-          (if (looking-at "^\\(.*\\):\\([0-9]+\\):\\([0-9]+\\)")
+          (if (looking-at "^\\(.*?\\):\\([0-9]+\\):\\([0-9]+\\)")
               (let ((file (match-string 1))
                     (line (string-to-number (match-string 2)))
                     (column (string-to-number (match-string 3))))


### PR DESCRIPTION
When looking at references I sometimes have results like

```
file:line:col   code("hi:4:5");
```

which messes up parsing since the regular expressions for the file are greedy.  Anyway, I changed them to be non-greedy and that has fixed my problems.  They could probably be changed to use `\S *` instead of `.*` for the file component, but this change was smaller and less likely to break something.

I looked through the rest of the elisp briefly.  I think `rtags-goto-location` and `rtags-taglist` are probably okay as is.  I don't understand the context of `rtags-filename-complete` and `rtags-find-file` well enough to judge.  I don't think there were any others.
