### PR TITLE
Prevent crashes (for me)

### DIFF
--- a/src/RClient.cpp
+++ b/src/RClient.cpp
@@ -550,7 +550,8 @@ bool RClient::exec()
         if (!ret)
             break;
     }
-    connection.client()->close();
+    if ( connection.client() )
+        connection.client()->close();
     mCommands.clear();
     ret = ret && (!requiresNon0Output || monitor.gotNon0Output);
     return ret;


### PR DESCRIPTION
I was experiencing a lot of crashes on my machine (OS X 10.9.2) until I made this change.  I usually run `make -j9` so that may be related.  I'm not sure if this is fixing a problem or papering over it, so feel free to ask me to debug further into it.
