### PR TITLE
Remove the optional ':' and EOL delimiter from code complete loc regex

### DIFF
--- a/src/RClient.cpp
+++ b/src/RClient.cpp
@@ -658,7 +658,7 @@ bool RClient::parse(int &argc, char **argv)
         case CodeCompleteAt: {
             const String arg = optarg;
             List<RegExp::Capture> caps;
-            RegExp rx("^\\(.*\\):\\([0-9][0-9]*\\):\\([0-9][0-9]*\\):\\?$");
+            RegExp rx("^\\(.*\\):\\([0-9][0-9]*\\):\\([0-9][0-9]*\\)");
             if (rx.indexIn(arg, 0, &caps) != 0 || caps.size() != 4) {
                 fprintf(stderr, "Can't decode argument for --code-complete-at [%s]\n", optarg);
                 return false;


### PR DESCRIPTION
Hello!

On Cygwin there appears to be some issue with the code completion location regex or its implementation - for every request I get the error message:

Can't decode argument for --code-complete-at /home/Brian/elisp/foreign/rtags/src/RClient.cpp:1087:9:]

Though I'm not sure what the underlying issue is, when I tried removing the optional `:` capture it works as intended.  I verified this change working on both my linux and cygwin machines.
