### PR TITLE
RTagsClang: fix compile error with g++

### DIFF
--- a/src/RTagsClang.cpp
+++ b/src/RTagsClang.cpp
@@ -1018,7 +1018,7 @@ String typeString(const CXType &type)
     if (type.kind == CXType_ConstantArray) {
         ret += typeString(clang_getArrayElementType(type));
 #if CLANG_VERSION_MAJOR > 3 || (CLANG_VERSION_MAJOR == 3 && CLANG_VERSION_MINOR >= 1)
-        const long long count = clang_getNumElements(type);
+        const int64_t count = clang_getNumElements(type);
         ret += '[';
         if (count >= 0)
             ret += String::number(count);


### PR DESCRIPTION
RTagsClang.cpp won't compile with g++ 4.9.0 since it can't find the
correct implementation of String::number().
This fix moves the type to uint64_t instead of long long, which
apparently works fine.
