### PR TITLE
Identify not indexed properly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,4 @@
 [submodule "src/rct"]
 	path = src/rct
-	url = https://github.com/farva/rct
+	url = https://github.com/Andersbakken/rct
 	branch = master
-        ignore = dirty


### PR DESCRIPTION
identify it also in some functions, specifically those from "Fall back to other taggers".
The example given didn't work properly.
