### PR TITLE
Change rtags-ac.el usage of `split-string`s TRIM

### DIFF
--- a/src/rtags-ac.el
+++ b/src/rtags-ac.el
@@ -95,7 +95,7 @@
 
     ;; for yasnippet, wrap each elem in arg list with ${}
     ;; 'int arg' => ${int arg}
-    (cond ((not (featurep 'yasnippet))
+    (cond ((featurep 'yasnippet)
 	   (setq inserttxt (mapconcat #'(lambda (arg) 
 					  (format "%s%s%s" "${" arg "}"))
 				      arglist


### PR DESCRIPTION
Hi,

Since some (older?) emacs appear to be missing the TRIM functionality of `split-string` I changed it to use `replace-regexp-in-string` on the beginning and end of the tag string instead.

The goal was to take a tag:  "int foo( const std::string& s, bool enabled )"
and create an arglist: '( "const std::string& s", "bool enabled" )

Then format the arglist for insertion through yasnippet (if available).

Feedback welcome

Thanks!
