### PR TITLE
Fix missing namespace completions in global namespace

### DIFF
--- a/src/CompletionThread.cpp
+++ b/src/CompletionThread.cpp
@@ -326,8 +326,6 @@ void CompletionThread::process(Request *request)
                 continue;
 
             const int priority = clang_getCompletionPriority(string);
-            if (priority >= 70)
-                continue;
 
             Completions::Candidate &node = nodes[nodeCount];
             node.cursorKind = kind;

--- a/src/rtags-ac.el
+++ b/src/rtags-ac.el
@@ -81,6 +81,9 @@
                (string= type "FunctionDecl")
                (string= type "FunctionTemplate"))
            (rtags-ac-action-function tag))
+	  ((or (string= type "Namespace")
+	       (string= type "NamespaceAlias"))
+	   (rtags-ac-action-namespace tag))
           (t
            nil))))
 
@@ -109,6 +112,9 @@
            (setq insertfunc #'(lambda (txt) (save-excursion (insert txt)) (forward-char)))
            (setq inserttxt (mapconcat 'identity arglist ", "))))
     (apply insertfunc (list (concat "(" inserttxt ")")))))
+
+(defun rtags-ac-action-namespace (origtag)
+  (insert "::"))
 
 (defun rtags-ac-prefix ()
   ;; shamelessly borrowed from clang-complete-async


### PR DESCRIPTION
Hi,

My setup has been missing completions for global namespaces.
Example:  the 'std' namespace isn't shown; the only near matches shown are stdin,stdout,stderr

However, when prefixing '::std', it would show a namespace completion.  Similarly, 'std::placeholders' was also available for completion.

Looking at CompletionThread.cpp it appears the priority for the first, missing case was '75' and it was being filtered away.  I'm not sure why the first case is a higher priority than the latter, but I didn't find much of a difference without priority filtering.

Relevant enum in clang c++ interface:
http://clang.llvm.org/doxygen/CodeCompleteConsumer_8h_source.html

(using clang 3.3)

Also added a rtags-ac completion action to auto-add the '::' to the end of a namespace.

Best Regards,
Brian
