### PR TITLE
Fixes and lint cleanup on wrapper

### DIFF
--- a/bin/gcc-rtags-wrapper.sh
+++ b/bin/gcc-rtags-wrapper.sh
@@ -4,16 +4,16 @@ if [ "$RTAGS_GCC_WRAPPER" = "1" ]; then
     echo 1>&2 "Recursive invocation of gcc-rtags-wrapper.sh detected"
     exit 1
 fi
-rc=`which rc`
-for i in `which -a "\`basename $0\`"`; do
-    filename=$(basename $(readlink "$i"))
+rc=$(which rc)
+for i in $(which -a "$(basename "$0")"); do
+    filename=$(basename "$(readlink "$i")")
     if [ "$filename" != "gcc-rtags-wrapper.sh" ] && [ -z "$PLAST" -o "$filename" != "plastc" ]; then
         [ -n "$RTAGS_SERVER_FILE" ] && RTAGS_ARGS="$RTAGS_ARGS -n$RTAGS_SERVER_FILE"
         [ -n "$RTAGS_PROJECT" ] && RTAGS_ARGS="$RTAGS_ARGS --project-root=$RTAGS_PROJECT"
         [ -z "$RTAGS_COMPILE_TIMEOUT" ] && RTAGS_COMPILE_TIMEOUT=3000
 
         if [ -z "$RTAGS_DISABLED" ] && [ -x "$rc" ]; then
-            $rc --timeout=$RTAGS_COMPILE_TIMEOUT $RTAGS_ARGS --silent --compile "$i" "$@" &
+            $rc --timeout="$RTAGS_COMPILE_TIMEOUT" "$RTAGS_ARGS" --silent --compile "$i" "$@" &
             disown &>/dev/null # rc might be finished by now and if so disown will yell at us
         fi
         [ "$RTAGS_RMAKE" ] && exit 0
@@ -22,8 +22,7 @@ for i in `which -a "\`basename $0\`"`; do
         "$i" "$@"
         exit $?
     else
-        dir=`dirname $i`
-        PATH=`echo $PATH | sed -e "s,$dir/*:*,,g"`
+        PATH="$(echo "$PATH" | sed -e "s,$(dirname "$i")/*:*,,g")"
     fi
 done
 exit 1 ### no compiler found?


### PR DESCRIPTION
I found some problems in `gcc-rtags-wrapper.sh` when looking at it to figure out what exactly it does.  I have not been able to test the changes as I am still trying to get rtags set up, but these changes should not break the behaviour with existing workflows (so long as the workflow does not workaround any bugs fixed here).
