### PR TITLE
Company-rtags should allow other engines to run if rtags is not available.

### DIFF
--- a/src/company-rtags.el
+++ b/src/company-rtags.el
@@ -84,7 +84,9 @@ and `c-electric-colon', for automatic completion right after \">\" and
   "`company-mode' completion back-end for `rtags'."
   (interactive (list 'interactive))
   (case command
-    (prefix (and (memq major-mode company-rtags-modes)
+    (interactive (company-begin-backend 'company-rtags))
+    (prefix (and (rtags-is-indexed)
+                 (memq major-mode company-rtags-modes)
                  buffer-file-name
                  (not (company-in-string-or-comment))
                  (company-rtags--prefix)))


### PR DESCRIPTION
Also adding interactive way of running company-rtags.
