### PR TITLE
Fix typo in boolean logic for indexing

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -367,7 +367,7 @@ bool Server::index(const String &arguments, const Path &pwd, const Path &project
         }
     }
 
-    if (!parse)
+    if (parse)
         sources = Source::parse(arguments, pwd, flags, &unresolvedPaths);
 
     bool ret = false;


### PR DESCRIPTION
Hi!  After upgrading, I was puzzled as to why rc -J and rc --compile didn't seem to index files.
Looks like it was just a typo; things are index'ing again

Regards