### PR TITLE
Fix rtags-goto-line-col

### DIFF
--- a/src/rtags.el
+++ b/src/rtags.el
@@ -608,11 +608,8 @@ BUFFER : the buffer to be checked and reparsed, if it's nil, use current buffer"
             (t (switch-to-buffer file-or-buffer))))))
 
 (defun rtags-goto-line-col (line column)
-  (goto-char (point-min))
-  (forward-line (1- line))
-  (beginning-of-line)
-  (if (>= (- (point-at-eol) (point)) column)
-      (forward-char (1- column))))
+  (goto-line line)
+  (move-to-column (1- column)))
 
 (defun rtags-goto-location (location &optional nobookmark other-window)
   "Go to a location passed in. It can be either: file,12 or file:13:14 or plain file"


### PR DESCRIPTION
Previous version did not always go to the correct column. Bug can be
reproduced with libc++ by trying to get a summary of
std::map::find(const key_type&)

The last try was missing -1 from the column, so the results were off by one. But now it seems to work correctly.