### PR TITLE
bugfix: don't skip diagnostic messages without a length

### DIFF
--- a/src/rtags.el
+++ b/src/rtags.el
@@ -1143,7 +1143,10 @@ References to references will be treated as references to the referenced symbol"
                       (when rsym
                         (setq endoffset (+ startoffset (length rsym)))))))))
 
-            (if (and startoffset endoffset filebuffer)
+            (when (not endoffset)
+              (setq endoffset (1+ startoffset)))
+
+            (if (and startoffset filebuffer)
                 (let ((overlay (make-overlay (1+ startoffset)
                                              (cond ((= startoffset endoffset) (+ startoffset 2))
                                                    (t (1+ endoffset)))


### PR DESCRIPTION
Some diagnostic messages won't have a end pointer or a length.  For Example, a
syntax error for a missing close paren will not.  In these cases, rtags should
still show the diagnostic.  Setting the length to a single character seems a
reasonable way to display these.