### PR TITLE
emacs: bugfix: repeat-on-final-keystroke is defined in repeat.el

### DIFF
--- a/src/rtags.el
+++ b/src/rtags.el
@@ -47,6 +47,7 @@
 (require 'thingatpt)
 (unless (fboundp 'libxml-parse-xml-region)
   (require 'xml))
+(require 'repeat)
 
 (defconst rtags-popup-available (require 'popup nil t))
 


### PR DESCRIPTION
and repeat.el isn't loaded by default, the previous change to this function in
commit 2147751 will fail if the user hasn't used C-x z yet.

Sorry!  I should have tested the earlier pull request better.