### PR TITLE
Adding rtags-get-include-file-for-symbol

### DIFF
--- a/src/rtags.el
+++ b/src/rtags.el
@@ -2412,7 +2412,6 @@ If rtags-display-summary-as-tooltip is t, a tooltip is displayed."
   t)
 (add-hook 'find-file-hook 'rtags-find-file-hook)
 
-(require 'cl-macs)
 (defun rtags-get-include-file-for-symbol ()
   "Insert #include declaration to buffer corresponding to the input symbol"
   (interactive)
@@ -2430,9 +2429,11 @@ If rtags-display-summary-as-tooltip is t, a tooltip is displayed."
                                                (setq raw-includes-list (split-string (buffer-substring-no-properties (point-min) (point-max)) "\n"))
                                                (completing-read "Pick definition: " raw-includes-list nil t))))
                       (when raw-include (car (split-string raw-include ":")))))
-    (when (and final-res rtags-include-prefixes) (cl-loop for prefix in rtags-include-prefixes
-                                                          do (if (string-match-p prefix final-res) (setq final-res (concat prefix (car (last (split-string final-res prefix))))))))
-    (when final-res (insert (concat "#include \"" final-res "\"\n")))))
+    (when final-res
+      (when rtags-include-prefixes
+        (mapc (λ(prefix) (if (string-match-p prefix final-res) (setq final-res (concat prefix (car (last (split-string final-res prefix)))))))
+              rtags-include-prefixes))
+      (insert (concat "#include \"" final-res "\"\n")))))
 
 (provide 'rtags)
 

--- a/src/rtags.el
+++ b/src/rtags.el
@@ -2412,6 +2412,28 @@ If rtags-display-summary-as-tooltip is t, a tooltip is displayed."
   t)
 (add-hook 'find-file-hook 'rtags-find-file-hook)
 
+(require 'cl-macs)
+(defun rtags-get-include-file-for-symbol ()
+  "Insert #include declaration to buffer corresponding to the input symbol"
+  (interactive)
+  (setq input (completing-read-default "Symbol: " (function rtags-symbolname-complete) nil nil nil 'rtags-symbol-history))
+  (setq rtags-symbol-history (cl-remove-duplicates rtags-symbol-history :from-end t :test 'equal))
+  (if (equal "" input) (message "You entered an empty symbol. Try again.")
+    (setq final-res (with-current-buffer (rtags-get-buffer "Rtags include help")
+                      (rtags-call-rc :path (buffer-file-name) "-F" input :path-filter (buffer-file-name) :path-filter-regex nil (if rtags-symbolnames-case-insensitive "-I"))
+                      (setq raw-include (cond ((= (point-min) (point-max))
+                                               (message "RTags: No results") nil)
+                                              ((= (count-lines (point-min) (point-max)) 1)
+                                               (buffer-substring-no-properties (point-min) (point-max)))
+                                              (t
+                                               (message "Results:\n%s" (buffer-substring-no-properties (point-min) (point-max)))
+                                               (setq raw-includes-list (split-string (buffer-substring-no-properties (point-min) (point-max)) "\n"))
+                                               (completing-read "Pick definition: " raw-includes-list nil t))))
+                      (when raw-include (car (split-string raw-include ":")))))
+    (when (and final-res rtags-include-prefixes) (cl-loop for prefix in rtags-include-prefixes
+                                                          do (if (string-match-p prefix final-res) (setq final-res (concat prefix (car (last (split-string final-res prefix))))))))
+    (when final-res (insert (concat "#include \"" final-res "\"\n")))))
+
 (provide 'rtags)
 
 ;;; rtags.el ends here


### PR DESCRIPTION
rtags-get-include-file-for-symbol uses a mechanism very similar to rtags-find-symbol-internal to list all definitions of a symbol. The list variable rtags-include-prefixes is used to shorten the include paths. For example, if "abc" is an element of rtags-include-prefixes and the symbol is defined in "path/to/file/in/abc/rest/of/path", rtags-get-include-file-for-symbol will insert "#include abc/rest/of/path" into the current buffer.