### PR TITLE
Fixed the output of 'rc --dump-compilation-database'

### DIFF
--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -1229,7 +1229,7 @@ String Project::toCompilationDatabase() const
         Value unit;
         unit["directory"] = source.second.directory;
         unit["file"] = source.second.sourceFile();
-        unit["command"] = source.second.toCommandLine(flags);
+        unit["command"] = String::join(source.second.toCommandLine(flags), " ").constData();
         ret[i++] = unit;
     }
 


### PR DESCRIPTION
Fixed the output of 'rc --dump-compilation-database' to match the [JSON Compilation Database Format Specification](http://clang.llvm.org/docs/JSONCompilationDatabase.html).

The command should be a single string, rather than an array of strings.