### PR TITLE
launchd support on OS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ compile_commands.json
 /tests/186/
 /install_manifest.txt
 /build/
+.dir-locals.el

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src/rct"]
         path = src/rct
-        url = https://github.com/Andersbakken/rct
-        branch = master
+        url = https://github.com/tom-seddon/rct
+        branch = _launchd

--- a/README.org
+++ b/README.org
@@ -254,6 +254,71 @@ $ cat ~/.rdmrc
 --data-dir=/other/dir
 #+END_SRC
 
+** Integration with =launchd= /(Mac OS X)/
+
+On Mac OS X, you can set =rdm= can be run on demand, on your behalf,
+by =launchd=, and have it exit cleanly after a period of inactivity.
+This isn't quite plug-and-play, but I think it worth the small amount
+of effort.
+
+1. Create a file, e.g., in emacs, with the following contents:
+
+   #+BEGIN_SRC
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.andersbakken.rtags.agent</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>sh</string>
+      <string>-c</string>
+      <string>$RDM -v --launchd --inactivity-timeout 300 --log-file ~/Library/Logs/rtags.launchd.log</string>
+    </array>
+    <key>Sockets</key>
+    <dict>
+      <key>Listener</key>
+      <dict>
+	<key>SockPathName</key>
+	<string>$HOME/.rdm</string>
+      </dict>
+    </dict>
+  </dict>
+</plist>
+   #+END_SRC
+
+2. Replace =$HOME= with the absolute path to your home folder. Replace
+   =$RDM= with the path to your copy of =rdm=, and add any command
+   line parameters you might usually use.
+
+   (The =SockPathName= entry relates to the name of the domain socket
+   that =rdm= uses. The settings above are for the default value; if
+   your command line options direct it to use some other name, please
+   modify it to suit. Unfortunately =launchd='s configuration files
+   are a bit naff, so you'll have to repeat yourself.)
+
+3. Save the result as
+   =~/Library/LaunchAgents/com.andersbakken.rtags.agent.plist=.
+
+4. Run the following command from the terminal:
+
+   : launchctl load ~/Library/LaunchAgents/com.andersbakken.rtags.agent.plist
+
+   (This will happen automatically next time you log back in.)
+
+5. Try using rtags, and you should find =rdm= will spring into life!
+
+*** Notes
+
+- =rdm= will automatically quit after 5 minutes of inactivity (this is
+  what the =--inactivity-timeout 300= command line option is for), so
+  it won't stick around hogging memory. But =launchd= will still be
+  watching its socket for activity, and will relaunch it if necessary.
+
+- You can watch =launchd='s logging by tailing
+  =~/Library/Logs/rtags.launchd.log=.
+
 * Usage
 
   Now that your files are indexed you can start using rtags. Normally

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,6 +60,7 @@ if (CMAKE_BUILD_TYPE MATCHES "Debug")
   set(RCT_EVENTLOOP_CALLBACK_TIME_THRESHOLD 2000)
 endif ()
 
+add_definitions("-Wno-vla")
 add_definitions("-Wall")
 add_definitions("-DCLANG_LIBDIR=${CLANG_LIBDIR}")
 add_definitions("-DOS_${CMAKE_SYSTEM_NAME}")

--- a/src/CompletionThread.h
+++ b/src/CompletionThread.h
@@ -109,6 +109,6 @@ private:
     std::condition_variable mCondition;
 };
 
-RCT_FLAGS(CompletionThread::Flag);
+RCT_FLAGS(CompletionThread::Flag)
 
 #endif

--- a/src/IndexDataMessage.h
+++ b/src/IndexDataMessage.h
@@ -118,8 +118,8 @@ private:
     Flags<Flag> mFlags;
 };
 
-RCT_FLAGS(IndexDataMessage::Flag);
-RCT_FLAGS(IndexDataMessage::FileFlag);
+RCT_FLAGS(IndexDataMessage::Flag)
+RCT_FLAGS(IndexDataMessage::FileFlag)
 
 inline void IndexDataMessage::encode(Serializer &serializer) const
 {

--- a/src/IndexMessage.h
+++ b/src/IndexMessage.h
@@ -55,6 +55,6 @@ private:
     Flags<Flag> mFlags;
 };
 
-RCT_FLAGS(IndexMessage::Flag);
+RCT_FLAGS(IndexMessage::Flag)
 
 #endif

--- a/src/IndexerJob.h
+++ b/src/IndexerJob.h
@@ -62,6 +62,6 @@ private:
     static uint64_t sNextId;
 };
 
-RCT_FLAGS(IndexerJob::Flag);
+RCT_FLAGS(IndexerJob::Flag)
 
 #endif

--- a/src/Location.h
+++ b/src/Location.h
@@ -181,7 +181,7 @@ public:
     {
         char path[PATH_MAX];
         uint32_t line, col;
-        if (sscanf(key.constData(), "%[^':']:%d:%d", path, &line, &col) != 3)
+        if (sscanf(key.constData(), "%[^':']:%u:%u", path, &line, &col) != 3)
             return String();
 
         Path resolved = Path::resolved(path, Path::MakeAbsolute, pwd);
@@ -199,7 +199,7 @@ public:
     {
         char path[PATH_MAX];
         uint32_t line, col;
-        if (sscanf(str.constData(), "%[^':']:%d:%d", path, &line, &col) != 3)
+        if (sscanf(str.constData(), "%[^':']:%u:%u", path, &line, &col) != 3)
             return Location();
 
         const Path resolved = Path::resolved(path, Path::RealPath, pwd);
@@ -262,7 +262,7 @@ private:
     static const uint64_t COLUMN_MASK;
 };
 
-RCT_FLAGS(Location::KeyFlag);
+RCT_FLAGS(Location::KeyFlag)
 
 template <> struct FixedSize<Location>
 {

--- a/src/Match.h
+++ b/src/Match.h
@@ -82,7 +82,7 @@ private:
     String mPattern;
     Flags<Flag> mFlags;
 };
-RCT_FLAGS(Match::Flag);
+RCT_FLAGS(Match::Flag)
 
 inline Log operator<<(Log log, const Match &match)
 {

--- a/src/Project.h
+++ b/src/Project.h
@@ -343,7 +343,7 @@ private:
     mutable std::mutex mMutex;
 };
 
-RCT_FLAGS(Project::SortFlag);
+RCT_FLAGS(Project::SortFlag)
 
 inline bool Project::visitFile(uint32_t visitFileId, const Path &path, uint64_t key)
 {

--- a/src/QueryJob.h
+++ b/src/QueryJob.h
@@ -96,8 +96,8 @@ private:
     std::shared_ptr<Connection> mConnection;
 };
 
-RCT_FLAGS(QueryJob::JobFlag);
-RCT_FLAGS(QueryJob::WriteFlag);
+RCT_FLAGS(QueryJob::JobFlag)
+RCT_FLAGS(QueryJob::WriteFlag)
 
 template <int StaticBufSize>
 inline bool QueryJob::write(Flags<WriteFlag> flags, const char *format, ...)

--- a/src/QueryMessage.h
+++ b/src/QueryMessage.h
@@ -175,7 +175,7 @@ private:
     UnsavedFiles mUnsavedFiles;
 };
 
-RCT_FLAGS(QueryMessage::Flag);
+RCT_FLAGS(QueryMessage::Flag)
 
 DECLARE_NATIVE_TYPE(QueryMessage::Type);
 

--- a/src/RTags.h
+++ b/src/RTags.h
@@ -221,7 +221,7 @@ enum FindAncestorFlag {
     Shallow = 0x1,
     Wildcard = 0x2
 };
-RCT_FLAGS(FindAncestorFlag);
+RCT_FLAGS(FindAncestorFlag)
 Path findAncestor(Path path, const char *fn, Flags<FindAncestorFlag> flags);
 Map<String, String> rtagsConfig(const Path &path);
 

--- a/src/RTagsClang.h
+++ b/src/RTagsClang.h
@@ -45,7 +45,7 @@ inline bool operator!=(CXCursorKind l, const CXCursor &r)
 inline Log operator<<(Log dbg, CXCursor cursor);
 inline Log operator<<(Log dbg, CXCursorKind kind);
 
-static inline bool operator==(const CXCursor &l, const CXCursor &r) { return clang_equalCursors(l, r); };
+static inline bool operator==(const CXCursor &l, const CXCursor &r) { return clang_equalCursors(l, r); }
 namespace std {
 template <> struct hash<CXCursor> : public unary_function<CXCursor, size_t>
 {
@@ -64,10 +64,10 @@ enum CursorToStringFlags {
     IncludeSpecializedUsr = 0x4,
     AllCursorToStringFlags = IncludeUSR|IncludeRange|IncludeSpecializedUsr
 };
-RCT_FLAGS(CursorToStringFlags);
+RCT_FLAGS(CursorToStringFlags)
 String cursorToString(CXCursor cursor, Flags<CursorToStringFlags> = DefaultCursorToStringFlags);
 
-RCT_FLAGS(CXTranslationUnit_Flags);
+RCT_FLAGS(CXTranslationUnit_Flags)
 
 void parseTranslationUnit(const Path &sourceFile, const List<String> &args,
                           CXTranslationUnit &unit, CXIndex index,

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -241,8 +241,6 @@ bool Server::initUnixServer()
     if (mOptions.options & Launchd) {
         mUnixServer.reset(new SocketServer);
         
-        printf("initUnixServer: launchd mode.\n");
-        
         bool good = false;
         int *fds = 0;
         size_t numFDs;

--- a/src/Server.h
+++ b/src/Server.h
@@ -71,7 +71,9 @@ public:
         EnableNDEBUG = 0x10000,
         Progress = 0x20000,
         Weverything = 0x40000,
-        NoComments = 0x80000
+        NoComments = 0x80000,
+        Launchd = 0x100000,     /* Only valid for Darwin... but you're
+                                 * not out of bits yet. */
     };
     struct Options {
         Options()
@@ -172,6 +174,8 @@ private:
     void onHttpClientReadyRead(const SocketClient::SharedPtr &socket);
     void connectToServer();
     void startJobs();
+    bool initUnixServer();
+    void removeSocketFile();
 
     typedef Hash<Path, std::shared_ptr<Project> > ProjectsMap;
     ProjectsMap mProjects;

--- a/src/Server.h
+++ b/src/Server.h
@@ -198,6 +198,6 @@ private:
     friend void saveFileIds();
 };
 
-RCT_FLAGS(Server::Option);
+RCT_FLAGS(Server::Option)
 
 #endif

--- a/src/Source.h
+++ b/src/Source.h
@@ -181,9 +181,9 @@ struct Source
                               List<Path> *unresolvedInputLocation = 0);
 };
 
-RCT_FLAGS(Source::Flag);
-RCT_FLAGS(Source::ParseFlag);
-RCT_FLAGS(Source::CommandLineFlag);
+RCT_FLAGS(Source::Flag)
+RCT_FLAGS(Source::ParseFlag)
+RCT_FLAGS(Source::CommandLineFlag)
 
 inline Source::Source()
     : fileId(0), compilerId(0), buildRootId(0), includePathHash(0),

--- a/src/Symbol.h
+++ b/src/Symbol.h
@@ -118,7 +118,7 @@ struct Symbol
     bool operator<(const Symbol &other) const { return location < other.location; }
 };
 
-RCT_FLAGS(Symbol::ToStringFlag);
+RCT_FLAGS(Symbol::ToStringFlag)
 
 template <> inline Serializer &operator<<(Serializer &s, const Symbol &t)
 {

--- a/src/rdm.cpp
+++ b/src/rdm.cpp
@@ -107,6 +107,9 @@ static void usage(FILE *f)
             "  --watch-system-paths|-w                    Watch system paths for changes.\n"
             "  --block-argument|-G [arg]                  Block this argument from being passed to clang. E.g. rdm --block-argument -fno-inline\n"
             "  --progress|-p                              Report compilation progress in diagnostics output.\n"
+#ifdef OS_Darwin
+            "  --launchd                                  Run as a launchd job (use launchd API to retrieve socket opened by launchd on rdm's behalf).\n"
+#endif
             "\nCompiling/Indexing options:\n"
             "  --allow-Wpedantic|-P                       Don't strip out -Wpedantic. This can cause problems in certain projects.\n"
             "  --define|-D [arg]                          Add additional define directive to clang.\n"
@@ -208,6 +211,9 @@ int main(int argc, char** argv)
         { "no-filesystem-watcher", no_argument, 0, 'B' },
         { "arg-transform", required_argument, 0, 'V' },
         { "no-comments", no_argument, 0, '\1' },
+#ifdef OS_Darwin
+        { "launchd", no_argument, 0, '\4' },
+#endif
         { 0, 0, 0, 0 }
     };
     const String shortOptions = Rct::shortOptions(opts);
@@ -610,6 +616,11 @@ int main(int argc, char** argv)
             if (logLevel >= 0)
                 ++logLevel;
             break;
+#ifdef OS_Darwin
+        case '\4':
+            serverOpts.options |= Server::Launchd;
+            break;
+#endif
         case '?': {
             fprintf(stderr, "Run rdm --help for help\n");
             return 1; }

--- a/src/rdm.cpp
+++ b/src/rdm.cpp
@@ -110,6 +110,9 @@ static void usage(FILE *f)
 #ifdef OS_Darwin
             "  --launchd                                  Run as a launchd job (use launchd API to retrieve socket opened by launchd on rdm's behalf).\n"
 #endif
+            // This only really makes sense if you're using --launchd.
+            // But the code isn't OS X-specific, strictly speaking.
+            "  --inactivity-timeout [arg]                 Time in seconds after which launchd will quit if there's been no activity (N.B., once rdm has quit, something will need to re-run it!).\n"
             "\nCompiling/Indexing options:\n"
             "  --allow-Wpedantic|-P                       Don't strip out -Wpedantic. This can cause problems in certain projects.\n"
             "  --define|-D [arg]                          Add additional define directive to clang.\n"
@@ -214,6 +217,7 @@ int main(int argc, char** argv)
 #ifdef OS_Darwin
         { "launchd", no_argument, 0, '\4' },
 #endif
+        { "inactivity-timeout", required_argument, 0, '\5' },
         { 0, 0, 0, 0 }
     };
     const String shortOptions = Rct::shortOptions(opts);
@@ -344,6 +348,7 @@ int main(int argc, char** argv)
     int argCount = argList.size();
     char **args = argList.data();
     bool defaultDataDir = true;
+    int inactivityTimeout = 0;
 
     while (true) {
         const int c = getopt_long(argCount, args, shortOptions.constData(), opts, 0);
@@ -621,6 +626,14 @@ int main(int argc, char** argv)
             serverOpts.options |= Server::Launchd;
             break;
 #endif
+        case '\5':
+            inactivityTimeout = atoi(optarg);
+            if (inactivityTimeout <= 0) {
+                fprintf(stderr, "Invalid argument to --inactivity-timeout %s\n", optarg);
+                return 1;
+            }
+                                       // seconds.
+            break;
         case '?': {
             fprintf(stderr, "Run rdm --help for help\n");
             return 1; }
@@ -651,6 +664,21 @@ int main(int argc, char** argv)
                 logLevel, logFile ? logFile : "", logFlags);
         return 1;
     }
+
+#ifdef OS_Darwin
+    if (serverOpts.options & Server::Launchd) {
+        // Clamp inactivity timeout. launchd starts to worry if the
+        // process runs for less than 10 seconds.
+        
+        static const int MIN_INACTIVITY_TIMEOUT = 15; // includes
+                                                      // fudge factor.
+        
+        if (inactivityTimeout < MIN_INACTIVITY_TIMEOUT) {
+            inactivityTimeout = MIN_INACTIVITY_TIMEOUT;
+            fprintf(stderr, "launchd mode - clamped inactivity timeout to %d to avoid launchd warnings.\n", inactivityTimeout);
+        }
+    }
+#endif
 
     EventLoop::SharedPtr loop(new EventLoop);
     loop->init(EventLoop::MainEventLoop|EventLoop::EnableSigIntHandler);
@@ -695,6 +723,8 @@ int main(int argc, char** argv)
     if (!serverOpts.tests.isEmpty()) {
         return server->runTests() ? 0 : 1;
     }
+
+    loop->setInactivityTimeout(inactivityTimeout * 1000);
 
     loop->exec();
     const int ret = server->exitCode();


### PR DESCRIPTION
I added some code to rtags to make it work as a user agent for OS X's launchd, when given an appropriate command line option. launchd can then run rdm automatically on demand (based on activity on the socket), and rdm will also cleanly exit after a period of inactivity.

For more about launchd: https://developer.apple.com/library/mac/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html

This pull request isn't made against the current HEAD, and it also involved changing rct (see https://github.com/tom-seddon/rct/commits/_launchd). But I thought I'd gauge interest before doing more. If you're interested in this code, I'll tidy it up and rebase it against HEAD - and figure out how to do the same with rct - so it can be merged cleanly. And if you're not, I'll just keep on top of things in my own time :)

--Tom

Main changes:

- shuts down cleanly on SIGTERM, since launchd sends SIGTERM when an agent is stopped
- inactivity timeout so that rdm doesn't stick around forever when you stop using it
- socket handling changes, since launchd now handles the creation and deletion of the domain socket (there's some OS X magic to let rdm retrieve its fd on startup)
- extra note in the docs

Bonus changes:

- when I built on gcc 4.9.2 on Linux, it gave me loads of warnings, so I fixed most of them, and popped a -Wno-vla in to stop it complaining about the rest


