### PR TITLE
Use vectors instead of non-standard variable length arrays

### DIFF
--- a/src/FileMap.h
+++ b/src/FileMap.h
@@ -26,6 +26,8 @@
 #include "Location.h"
 #include <functional>
 
+#include <vector>
+
 template <typename T> inline static int compare(const T &l, const T &r)
 {
     if (l < r)
@@ -221,7 +223,7 @@ public:
                 keySize = std::max<size_t>(str.size(), keySize);
             }
             memcpy(out.data() + sizeof(size_t), &keySize, sizeof(keySize));
-            char buf[keySize];
+            std::vector<char> buf(keySize);
             size_t entrySize = keySize;
             if (const size_t size = FixedSize<Value>::value) {
                 entrySize += size;
@@ -232,10 +234,10 @@ public:
             out.reserve(valuesOffset);
             idx = 0;
             for (const auto &pair : map) {
-                memset(buf, 0, sizeof(buf));
+                memset(&buf[0], 0, buf.size());
                 const String &str = keys[idx++];
-                memcpy(buf, str.data(), str.size()); // no need to copy the \0 :-)
-                encodePair(buf, keySize, pair.second);
+                memcpy(&buf[0], str.data(), str.size()); // no need to copy the \0 :-)
+                encodePair(&buf[0], keySize, pair.second);
             }
         } else {
             size_t entrySize = FixedSize<Key>::value;

--- a/src/rdm.cpp
+++ b/src/rdm.cpp
@@ -28,6 +28,8 @@
 #include <sys/resource.h>
 #endif
 
+#include <vector>
+
 static void sigSegvHandler(int signal)
 {
     if (Server *server = Server::instance())
@@ -240,8 +242,8 @@ int main(int argc, char** argv)
         Path rcfile = Path::home() + ".rdmrc";
         opterr = 0;
 
-        char *originalArgv[argc];
-        memcpy(originalArgv, argv, sizeof(originalArgv));
+        std::vector<char*> originalArgv(argc);
+        memcpy(&originalArgv[0], argv, sizeof(originalArgv));
         /* getopt will molest argv by moving pointers around when it sees
          * fit. Their idea of an optional argument is different from ours so we
          * have to take a copy of argv before they get their sticky fingers all


### PR DESCRIPTION
Hi Anders,

please find attached a patch that replaces use of non-standard variable length arrays with vectors. The trunk version of clang warns when seeing VLAs. The only downside of using vectors is that their memory is likely not allocated on the stack.