### PR TITLE
Add a virtual dtr to class with virtual methods

### DIFF
--- a/src/QueryJob.h
+++ b/src/QueryJob.h
@@ -45,7 +45,7 @@ public:
     QueryJob(const std::shared_ptr<QueryMessage> &msg,
              const std::shared_ptr<Project> &proj,
              Flags<JobFlag> jobFlags = Flags<JobFlag>());
-    ~QueryJob();
+    virtual ~QueryJob();
 
     bool hasFilter() const { return !mPathFilters.isEmpty() || !mPathFiltersRegex.isEmpty(); }
     List<String> pathFilters() const { return mPathFilters; }


### PR DESCRIPTION
Hi Anders,

please find attached a patch that adds a `virtual` destructor to a polymorphic class . The trunk version of clang warns when seeing class declarations like this. An alternative fix would be to make the class `final`, but I guess in this case leaving out the `virtual` was likely only an oversight.