### PR TITLE
Fix compile error

### DIFF
--- a/src/ClangIndexer.cpp
+++ b/src/ClangIndexer.cpp
@@ -26,6 +26,7 @@
 #include "RTags.h"
 #include "Diagnostic.h"
 #include "RClient.h"
+#include "clang-c/Documentation.h"
 #include <unistd.h>
 
 static const CXSourceLocation nullLocation = clang_getNullLocation();


### PR DESCRIPTION
I am getting compile errors with a recent clang...

/Users/ekr/src/rtags/src/ClangIndexer.cpp:1111:15: error: unknown type name 'CXComment'; did you mean
      'Comment'?
        const CXComment comment = clang_Cursor_getParsedComment(cursor);
              ^~~~~~~~~
              Comment
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/AIFF.h:191:41: note:
      'Comment' declared here
typedef struct Comment                  Comment;
                                        ^
/Users/ekr/src/rtags/src/ClangIndexer.cpp:1111:35: error: use of undeclared identifier
      'clang_Cursor_getParsedComment'; did you mean 'clang_Cursor_getBriefCommentText'?
        const CXComment comment = clang_Cursor_getParsedComment(cursor);
                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                  clang_Cursor_getBriefCommentText
