### PR TITLE
Compile with only ncurses

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,7 +96,7 @@ endif ()
 add_executable(rc rc.cpp RClient.cpp)
 target_link_libraries(rc rtags rct)
 
-set(RTAGS_CLANG_LIBRARIES rtags rct ${START_GROUP} ${CLANG_LIBS} ${END_GROUP} -lstdc++ ${CURSES_CURSES_LIBRARY})
+set(RTAGS_CLANG_LIBRARIES rtags rct ${START_GROUP} ${CLANG_LIBS} ${END_GROUP} -lstdc++ ${CURSES_LIBRARIES})
 set(RTAGS_CLANG_SOURCES RTagsClang.cpp Source.cpp)
 
 add_executable(rdm


### PR DESCRIPTION
CURSES_CURSES_LIBRARY is unnecessarily restrictive; CURSES_LIBRARIES will be set even if curses is not available.  This compiles on Ubuntu.