### PR TITLE
Fix parentheses warning

### DIFF
--- a/src/ClangIndexer.cpp
+++ b/src/ClangIndexer.cpp
@@ -1205,7 +1205,7 @@ static inline Map<String, Set<Location> > convertTargets(const Map<Location, Map
 bool ClangIndexer::writeFiles(const Path &root, String &error)
 {
     for (const auto &unit : mUnits) {
-        if (!mIndexDataMessage.files().value(unit.first) & IndexDataMessage::Visited) {
+        if (!(mIndexDataMessage.files().value(unit.first) & IndexDataMessage::Visited)) {
             ::error() << "Wanting to write something for" << Location::path(unit.first) << "but we didn't visit it" << mSource.sourceFile()
                       << unit.second->targets.size()
                       << unit.second->usrs.size()


### PR DESCRIPTION
When compiling we are getting a warning due to operator evaluation precedence ambiguity.

```
/home/lefteris/.emacs.d/el-get/rtags/src/ClangIndexer.cpp:1208:56: warning: suggest parentheses around operand of ‘!’ or change ‘&’ to ‘&&’ or ‘!’ to ‘~’ [-Wparentheses]
         if (!mIndexDataMessage.files().value(unit.first) & IndexDataMessage::Visited) {
                                                        ^
```

 This should fix it.