### PR TITLE
Use file checksums to determine dirtiness for partial reindexes

### DIFF
--- a/src/RTags.h
+++ b/src/RTags.h
@@ -38,7 +38,7 @@ namespace RTags {
 enum {
     MajorVersion = 2,
     MinorVersion = 0,
-    DatabaseVersion = 69
+    DatabaseVersion = 70
 };
 
 inline String versionString()

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -26,7 +26,7 @@ void Source::clear()
     fileId = compilerId = buildRootId = 0;
     includePathHash = 0;
     language = NoLanguage;
-    parsed = 0;
+    hashWhenLastParsed = "0";
 
     defines.clear();
     includePaths.clear();
@@ -53,8 +53,8 @@ String Source::toString() const
     String ret = String::join(toCommandLine(IncludeCompiler|IncludeSourceFile|IncludeIncludepaths|QuoteDefines|IncludeDefines), ' ');
     if (buildRootId)
         ret << " Build: " << buildRoot();
-    if (parsed)
-        ret << " Parsed: " << String::formatTime(parsed / 1000, String::DateTime);
+    if (hashWhenLastParsed != "0")
+        ret << " Hash when parsed: " << hashWhenLastParsed;
     if (flags & Active)
         ret << " Active";
     return ret;

--- a/src/Source.h
+++ b/src/Source.h
@@ -42,7 +42,7 @@ struct Source
 
     static const char *languageName(Language language);
 
-    uint64_t parsed;
+    String hashWhenLastParsed;
 
     enum Flag {
         NoFlag = 0x0,
@@ -187,7 +187,7 @@ RCT_FLAGS(Source::CommandLineFlag);
 
 inline Source::Source()
     : fileId(0), compilerId(0), buildRootId(0), includePathHash(0),
-      language(NoLanguage), parsed(0), sysRootIndex(-1)
+      language(NoLanguage), hashWhenLastParsed("0"), sysRootIndex(-1)
 {
 }
 
@@ -317,7 +317,7 @@ template <> inline Deserializer &operator>>(Deserializer &s, Source::Include &d)
 template <> inline Serializer &operator<<(Serializer &s, const Source &b)
 {
     s << b.fileId << b.compilerId << b.buildRootId << static_cast<uint8_t>(b.language)
-      << b.parsed << b.flags << b.defines << b.includePaths << b.arguments << b.sysRootIndex
+      << b.hashWhenLastParsed << b.flags << b.defines << b.includePaths << b.arguments << b.sysRootIndex
       << b.directory << b.includePathHash;
     return s;
 }
@@ -326,7 +326,7 @@ template <> inline Deserializer &operator>>(Deserializer &s, Source &b)
 {
     b.clear();
     uint8_t language;
-    s >> b.fileId >> b.compilerId >> b.buildRootId >> language >> b.parsed >> b.flags
+    s >> b.fileId >> b.compilerId >> b.buildRootId >> language >> b.hashWhenLastParsed >> b.flags
       >> b.defines >> b.includePaths >> b.arguments >> b.sysRootIndex >> b.directory
       >> b.includePathHash;
     b.language = static_cast<Source::Language>(language);


### PR DESCRIPTION
Using mtime to determine file dirtiness for reindexing is somewhat inaccurate when switching branches in git. In particular, it often leads to reindexing many files that have not actually changed. Using file checksums is 100% accurate, since it bases the decision to reindex on whether the content of the file has changed. I've been using this patch for a while now on my codebase at work (~1M LOC, mixed C and C++) and have found it vastly reduces the number of files being reindexed when I rebase or switch branches.

Note that this relies on pull request 25 in rct.