### PR TITLE
parse -ivfsoverlay correctly

### DIFF
--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -268,6 +268,7 @@ static const char* valueArgs[] = {
     "-iwithprefixbefore",
     "-imultilib",
     "-isysroot",
+    "-ivfsoverlay",
     "-Xpreprocessor",
     "-Xassembler",
     "-Xlinker",


### PR DESCRIPTION
-ivfsoverlay is a clang option that takes a filename argument.  It needs to go
 in this list so the argument doesn't get stripped off.

Signed-off-by: Lawrence D'Anna <larry@elder-gods.org>