### PR TITLE
Normalize source and project paths more aggressively

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -473,6 +473,8 @@ bool Server::index(const String &args,
             }
         }
 
+        root.resolve(Path::RealPath, pwd);
+
         if (shouldIndex(source, root)) {
             std::shared_ptr<Project> &project = mProjects[root];
             if (!project) {

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -590,8 +590,8 @@ List<Source> Source::parse(const String &cmdLine,
                         p.canonicalize();
                     }
                     buildRoot = RTags::findProjectRoot(p, RTags::BuildRoot);
+                    buildRoot.resolve(Path::RealPath, cwd);
                     if (buildRoot.isDir()) {
-                        buildRoot.resolve(Path::RealPath);
                         buildRootId = Location::insertFile(buildRoot);
                     } else {
                         buildRoot.clear();
@@ -636,7 +636,7 @@ List<Source> Source::parse(const String &cmdLine,
             if (add) {
                 const Language lang = language != NoLanguage ? language : guessLanguageFromSourceFile(resolved);
                 if (lang != NoLanguage) {
-                    inputs.append({resolved, Path::resolved(arg, Path::MakeAbsolute, cwd), lang});
+                    inputs.append({resolved, Path::resolved(arg, Path::RealPath, cwd), lang});
                 } else {
                     warning() << "Can't figure out language for" << arg;
                 }
@@ -658,7 +658,7 @@ List<Source> Source::parse(const String &cmdLine,
     if (!inputs.isEmpty()) {
         if (!buildRootId) {
             buildRoot = RTags::findProjectRoot(inputs.first().realPath, RTags::BuildRoot);
-            buildRoot.resolve(Path::RealPath);
+            buildRoot.resolve(Path::RealPath, cwd);
             buildRootId = Location::insertFile(buildRoot);
         }
         includePathHash = ::hashIncludePaths(includePaths, buildRoot);


### PR DESCRIPTION
This prevents `..` components sneaking into the database
when running a command like:

    rc --project-root=.. -c cc -o src/foo.o -c ../src/foo.c