### PR TITLE
Add version to rtags.el

### DIFF
--- a/src/rtags.el
+++ b/src/rtags.el
@@ -5,6 +5,7 @@
 ;; Author: Jan Erik Hanssen <jhanssen@gmail.com>
 ;;         Anders Bakken <agbakken@gmail.com>
 ;; URL: http://rtags.net
+;; Version: 2.0
 ;; Package-Requires: ((popup "0.5.3"))
 
 ;; This file is not part of GNU Emacs.


### PR DESCRIPTION
This allows `package-buffer-info` to parse the header, which is handy for writing package management scripts.