### PR TITLE
Compilation flags cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   set(CMAKE_COMPILER_IS_CLANGCXX TRUE)
 endif()
 
-if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANGCXX)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra -Wall -Wstrict-aliasing=2")
-  # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -fno-rtti -fno-exceptions")
-endif()
-
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,12 +10,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   set(CMAKE_COMPILER_IS_CLANGCXX TRUE)
 endif()
 
-if ("${CMAKE_GENERATOR}" STREQUAL "Ninja")
-  if (CMAKE_COMPILER_IS_CLANGCXX)
-    add_definitions("-fcolor-diagnostics")
-  endif()
-endif()
-
 if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANGCXX)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra -Wall -Wstrict-aliasing=2")
   # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -fno-rtti -fno-exceptions")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,16 +12,6 @@ IF("${isSystemDir}" STREQUAL "-1")
   SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 ENDIF("${isSystemDir}" STREQUAL "-1")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
-if (NOT CYGWIN)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-all")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstack-protector")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wstack-protector")
-endif ()
-
 include(${CMAKE_SOURCE_DIR}/cmake/EnsureLibraries.cmake)
 
 if (NOT DEFINED CLANG_LIBS)
@@ -43,7 +33,8 @@ endif ()
 find_package(Curses REQUIRED)
 
 string(REGEX REPLACE "-[Og][0-9]*" "" CLANG_CXXFLAGS "${CLANG_CXXFLAGS}")
-
+string(REPLACE "-DNDEBUG" "" CLANG_CXXFLAGS "${CLANG_CXXFLAGS}")
+string(REPLACE "-std=c++11" "" CLANG_CXXFLAGS "${CLANG_CXXFLAGS}")
 set(CMAKE_CXX_FLAGS ${CLANG_CXXFLAGS})
 
 if (EXISTS ${CLANG_COMPILATION_INCLUDE})
@@ -55,13 +46,18 @@ set(RCT_NO_INSTALL 1)
 add_subdirectory(rct)
 
 include(${CMAKE_CURRENT_LIST_DIR}/rct/compiler.cmake)
+# Set further compile options after including the rct compiler option.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstrict-aliasing=2")
+if (NOT CYGWIN)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-all -Wstack-protector")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all -Wstack-protector")
+endif ()
 
 if (CMAKE_BUILD_TYPE MATCHES "Debug")
   add_definitions("-DRTAGS_DEBUG")
   set(RCT_EVENTLOOP_CALLBACK_TIME_THRESHOLD 2000)
 endif ()
 
-add_definitions("-Wall")
 add_definitions("-DCLANG_LIBDIR=${CLANG_LIBDIR}")
 add_definitions("-DOS_${CMAKE_SYSTEM_NAME}")
 


### PR DESCRIPTION
Hey Anders,

the compilation flags are a bit messy :-) There where quite a few option clashes in there, due to the inclusion of the rct/compiler.cmake file and setting `CMAKE_CXX_FLAGS to CLANG_CXXFLAGS`, which btw overwrote all previously set cxx flags. I'm still not done, so do not merge it, just want to notify you about it. Also I made some changes in the `rct` project, maybe you can have a lock at it https://github.com/cslux/rct/commits/master. If you are happy with the changes in `rct` I'll create a pull request for that too.

That's what the compilation flags of one translation unit in src/rct would look like, still some clashes in there.
``` bash
cd /home/cschwarzgruber/Developing/third_party/rtags/build/release/src/rct && /bin/c++   -DOS_Linux -DRCT_HAVE_ZLIB -I/usr/include  -DNDEBUG -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS  -fomit-frame-pointer -std=c++11 -fvisibility-inlines-hidden -fno-exceptions -fPIC -Woverloaded-virtual -ffunction-sections -fdata-sections -Wcast-qual -Wall -Wextra -Wshadow -Wpointer-arith -Wnon-virtual-dtor -fno-rtti -std=c++11 -g -I/home/cschwarzgruber/Developing/third_party/rtags/src/rct -I/home/cschwarzgruber/Developing/third_party/rtags/build/release/src/rct/include/rct -I/home/cschwarzgruber/Developing/third_party/rtags/build/release/src/rct/include/rct/..    -o CMakeFiles/rct.dir/rct/Rct.cpp.o -c /home/cschwarzgruber/Developing/third_party/rtags/src/rct/rct/Rct.cpp
```
and here one of src/*.cpp
``` bash
cd /home/cschwarzgruber/Developing/third_party/rtags/build/release/src && /bin/c++   -DCLANG_LIBDIR=/usr/lib64/llvm -DOS_Linux -DRTAGS_BIN=\"/home/cschwarzgruber/Developing/third_party/rtags/build/release/bin/\" -DRTAGS_DEBUG -I/usr/include  -DNDEBUG -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS  -fomit-frame-pointer -std=c++11 -fvisibility-inlines-hidden -fno-exceptions -fPIC -Woverloaded-virtual -ffunction-sections -fdata-sections -Wcast-qual -Wstrict-aliasing=2 -fstack-protector-all -Wstack-protector  -g -I/home/cschwarzgruber/Developing/third_party/rtags/src -I/home/cschwarzgruber/Developing/third_party/rtags/src/rct/include -I/home/cschwarzgruber/Developing/third_party/rtags/src/rct -I/home/cschwarzgruber/Developing/third_party/rtags/build/release/src/rct/include/rct    -o CMakeFiles/rc.dir/rc.cpp.o -c /home/cschwarzgruber/Developing/third_party/rtags/src/rc.cpp
```

What needs still to be done is removing the `-DNDEBUG` and `-std=c++11` from the `CLANG_CXXFLAGS`.

regards,
Christian