### PR TITLE
Fix for SSO strings of gcc >= 5.1

### DIFF
--- a/src/CompletionThread.h
+++ b/src/CompletionThread.h
@@ -86,7 +86,8 @@ private:
     };
 
     void printCompletions(const List<Completions::Candidate> &completions, Request *request);
-    static int compareCompletionCandidates(const void *left, const void *right);
+    static bool compareCompletionCandidates(Completions::Candidate *l,
+                                            Completions::Candidate *r);
 
     struct SourceFile {
         SourceFile()


### PR DESCRIPTION
Hi, qsort did shuffle std::strings as raw bytes which does not work for the new string implementation of libc++ since 5.1.

Valgrind showed a few more leaks, in case you weren't aware of them.
 
Thanks for this awesome tool btw!