### PR TITLE
Restrict substitution in elisp files to @ONLY.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -152,7 +152,7 @@ endif ()
 
 foreach(el rtags.el rtags-ac.el company-rtags.el)
     if (NOT "${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
-        configure_file(${el} ${CMAKE_CURRENT_BINARY_DIR}/${el})
+        configure_file(${el} ${CMAKE_CURRENT_BINARY_DIR}/${el} @ONLY)
     endif ()
     add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${el}c
         COMMAND ${EMACS_EXECUTABLE} -batch -l ${CMAKE_CURRENT_LIST_DIR}/compile-shim.el -l ${CMAKE_CURRENT_LIST_DIR}/rtags.el -f batch-byte-compile


### PR DESCRIPTION
This fixes a problem where configure_file() would fail because
it tried to substitute values in legit syntax in the code, e.g.,
${int arg}.

Errors like...

CMake Error at src/CMakeLists.txt:155 (configure_file):
  Syntax error in cmake code when parsing string

        ;; 'int arg' => ${int arg}

  syntax error, unexpected cal_SYMBOL, expecting } (30)

CMake Error at src/CMakeLists.txt:155 (configure_file):
  Syntax error in cmake code when parsing string

                                              (format "%s%s%s" "${" arg
"}"))

  syntax error, unexpected cal_SYMBOL, expecting } (70)