### PR TITLE
Support elisp installation from out-of-source builds.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,14 +153,11 @@ endif ()
 if (NOT RTAGS_ELISP_INSTALL_LOCATION)
     set(RTAGS_ELISP_INSTALL_LOCATION ${CMAKE_INSTALL_PREFIX}/share/emacs/site-lisp/rtags/)
 endif ()
-set(RTAGS_ELISP_SOURCES "")
 foreach(el rtags.el rtags-ac.el company-rtags.el)
-    list(APPEND RTAGS_ELISP_SOURCES ${el})
     if (NOT "${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
-        configure_file(${el} ${CMAKE_CURRENT_BINARY_DIR}/${el} @ONLY)
+        install(FILES ${el} DESTINATION ${RTAGS_ELISP_INSTALL_LOCATION})
     endif ()
     if (NOT RTAGS_NO_ELISP_BYTECOMPILE)
-    list(APPEND RTAGS_ELISP_SOURCES ${el}c)
         add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${el}c
             COMMAND ${EMACS_EXECUTABLE} -batch -l ${CMAKE_CURRENT_LIST_DIR}/compile-shim.el -l ${CMAKE_CURRENT_LIST_DIR}/rtags.el -f batch-byte-compile
             ${CMAKE_CURRENT_BINARY_DIR}/${el}
@@ -168,6 +165,7 @@ foreach(el rtags.el rtags-ac.el company-rtags.el)
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             COMMENT "Creating byte-compiled Emacs lisp ${CMAKE_CURRENT_BINARY_DIR}/${el}c")
         add_custom_target(emacs_byte_compile_${el} ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${el}c)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${el}c DESTINATION ${RTAGS_ELISP_INSTALL_LOCATION})
     endif ()
 endforeach()
 
@@ -189,4 +187,3 @@ endif()
 install(TARGETS rdm rc rp RUNTIME DESTINATION bin COMPONENT rtags)
 install(FILES ../bin/gcc-rtags-wrapper.sh DESTINATION bin)
 install(FILES ../man/man7/rc.7 ../man/man7/rdm.7 DESTINATION share/man/man7/)
-install(FILES ${RTAGS_ELISP_SOURCES} DESTINATION ${RTAGS_ELISP_INSTALL_LOCATION})


### PR DESCRIPTION
When using an out-of-source build style, the generated installer would
look in the source for elisp (and compiled elisp) files rather than in
the build directory.

This eliminates the "configure_file" step that had no effect anyway and
replaces it with an install directive at that site.  The compiled elisp
custom command also learns how to do an install.