### PR TITLE
Handle "NotImplemented" response

### DIFF
--- a/src/company-rtags.el
+++ b/src/company-rtags.el
@@ -81,6 +81,7 @@ and `c-electric-colon', for automatic completion right after \">\" and
 (defun company-rtags--valid-candidate (prefix cand)
   (and (or (not prefix)
            (string-prefix-p prefix (car cand)))
+       (not (string= (nth 2 cand) "NotImplemented"))
        (let ((prefix-type (company-rtags--prefix-type)))
          (or (not prefix-type)
              (eq prefix-type 'company-rtags-colons)


### PR DESCRIPTION
I received errors from rtags-company-diagnostics-hook where (car candidates) returned ("" "" "NotImplemented"), this quieted things down.