### PR TITLE
Fix TLDR Quickstart

### DIFF
--- a/README.org
+++ b/README.org
@@ -30,15 +30,15 @@ he assured us clang was the way to go. The name stuck though.
 $ cd rtags
 $ cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=1
 $ make
-$ rdm &
-$ rc -J .
+$ ./bin/rdm &
+$ ./bin/rc -J .
 $ # wait for rdm to be silent
 $ emacs src/rdm.cpp
-(require 'rtags)
-# Go to /Users/abakken/dev/rtags-master/src/rdm.cpp:30:34     if (Server *server = Server::instance())
+(load-file "rtags.el")
+# Go to /Users/abakken/dev/rtags-master/src/rdm.cpp:39:34     if (Server *server = Server::instance())
 #                                                                                         /|\
 #                                                                                          |
-(rtags-follow-symbol-at-point)
+(rtags-find-symbol-at-point)
 # Your location is now on the definition of Server::instance()
 #+END_SRC
 


### PR DESCRIPTION
`rtags-follow-symbol-at-point' is obsolete. Also can't assume assume
"src" directory is in `load-path'.