### PR TITLE
fix work with -include f.h, while f.h.pch exists

### DIFF
--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -809,7 +809,11 @@ static inline bool isPch(const Path &path)
                 }
             }
         }
-        return false;
+        /* according to
+           http://clang.llvm.org/docs/UsersManual.html#command-line-options
+           -include can be passed with plain text header as argument, but
+           clang will be use .h.pch if it is exists, so let's check it
+         */
     }
 
     for (const char *suffix : { ".gch", ".pch" }) {
@@ -851,6 +855,8 @@ List<String> Source::toCommandLine(Flags<CommandLineFlag> flags) const
                 skip = true;
             } else if (arg == "-include") {
                 skip = isPch(arguments.value(i + 1));
+                if (skip)
+                    ++i;//we need skip option and arg
             }
         }
         if (!skip && remove.contains(arg))


### PR DESCRIPTION
This commit fix for me work of rdm with my project.
First of all I use -include file.h, while file.h.gch exists.
clang and gcc accept this, but rdm isPch check return false for such construction.

Plus for some reason even if isPch == true, then it skips only "-include", but not it's args,
and with such arguments clang_parseTranslationUnit2 return CXError_ASTReadError,

so rdm can not index any file of my project.