### PR TITLE
bugfix: rtags not working under launchd.

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -233,6 +233,8 @@ bool Server::initServers()
         free(fds);
         fds = 0;
 
+        mUnixServer->newConnection().connect(std::bind(&Server::onNewConnection, this, std::placeholders::_1));
+
         return good;
     }
 #endif


### PR DESCRIPTION
Looks like the callback is only getting attached if it's not --launchd.