### PR TITLE
enhancement #477: let rtags handle the project that sits on remote site.

### DIFF
--- a/src/rtags.el
+++ b/src/rtags.el
@@ -2797,12 +2797,11 @@ is true. References to references will be treated as references to the reference
 ;;;###autoload
 (defun rtags-copy-and-print-current-location()
   (interactive)
-  (when (rtags-sandbox-id-matches)
-    (let ((loc (rtags-current-location)))
-      (if (not loc)
-          (message "No current location!")
-        (kill-new loc)
-        (message loc)))))
+  (let ((loc (rtags-current-location)))
+    (if (not loc)
+        (message "No current location!")
+      (kill-new loc)
+      (message loc))))
 
 (defun rtags-all-files (prefer-exact)
   (with-temp-buffer

--- a/src/rtags.el
+++ b/src/rtags.el
@@ -85,7 +85,8 @@ ask - ask the user if sandbox should be changed. After 'yes',
 t   - change the sandbox and do the command.
 
 Note: if *RTags Diagnostics* is not running, then the 'match check'
-      is not performed, because sandbox tracking is not needed then.")
+      is not performed, because sandbox tracking is not needed then.
+Note: it is recommended to run each sandbox is separate emacs process.")
 
 (defun rtags-remove (predicate seq &optional not)
   (let ((ret))
@@ -897,7 +898,7 @@ Can be used both for path and location."
 ;;;###autoload
 (defun rtags-preprocess-file (&optional buffer)
   (interactive)
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (unless buffer (setq buffer (current-buffer)))
     (let (narrow-start narrow-end)
       (when (and mark-active
@@ -984,7 +985,7 @@ Can be used both for path and location."
                                  (noerror nil)
                                  (no-reparse nil))
   (interactive)
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (let ((loc (or location (rtags-current-location)))
           (path (buffer-file-name)))
       (when (not no-reparse)
@@ -1204,7 +1205,7 @@ Can be used both for path and location."
 
 (defun rtags-dependency-tree (&optional all)
   (interactive "P")
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (let ((dep-buffer (rtags-get-buffer "*RTags Dependencies*"))
           (deps)
           (fn (buffer-file-name)))
@@ -1237,7 +1238,7 @@ Can be used both for path and location."
 
 (defun rtags-dependency-tree-all ()
   (interactive)
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (rtags-dependency-tree t)))
 
 (defvar rtags-references-tree-data nil)
@@ -1399,7 +1400,7 @@ Can be used both for path and location."
 ;;;###autoload
 (defun rtags-references-tree ()
   (interactive)
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (rtags-reset-bookmarks)
     (rtags-delete-rtags-windows)
     (let ((ref-buffer (rtags-get-buffer "*RTags*"))
@@ -1456,7 +1457,7 @@ Can be used both for path and location."
 ;;;###autoload
 (defun rtags-print-source-arguments (&optional buffer)
   (interactive)
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (let ((args-buffer (rtags-get-buffer))
           (source (buffer-file-name buffer)))
       (when source
@@ -1473,7 +1474,7 @@ Can be used both for path and location."
 ;;;###autoload
 (defun rtags-print-class-hierarchy()
   (interactive)
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (let ((class-hierarchy-buffer (rtags-get-buffer))
           (path (buffer-file-name))
           (location (rtags-current-location)))
@@ -1490,7 +1491,7 @@ Can be used both for path and location."
 ;;;###autoload
 (defun rtags-print-enum-value-at-point (&optional location)
   (interactive)
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (let* ((symbol (rtags-symbol-info-internal location))
            (enum (or (cdr (assoc 'enumValue symbol))
                      (cdr (assoc 'enumValue (cdr (cadr (assoc 'targets symbol)))))))
@@ -1780,7 +1781,7 @@ For references this means to jump to the definition/declaration of the reference
 For definitions it jumps to the declaration (if there is only one) For declarations it jumps to the definition.
 If called with a prefix restrict to current buffer"
   (interactive "P")
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (rtags-delete-rtags-windows)
     (rtags-location-stack-push)
     (let ((arg (rtags-current-location))
@@ -1812,7 +1813,7 @@ If there's exactly one result jump directly to it. If there's more show a buffer
 with the different alternatives and jump to the first one if `rtags-jump-to-first-match'
 is true. References to references will be treated as references to the referenced symbol"
   (interactive "P")
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (rtags-delete-rtags-windows)
     (rtags-location-stack-push)
     (let ((arg (rtags-current-location))
@@ -1826,7 +1827,7 @@ is true. References to references will be treated as references to the reference
 (defun rtags-find-virtuals-at-point (&optional prefix)
   "List all reimplentations of function under cursor. This includes both declarations and definitions"
   (interactive "P")
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (rtags-delete-rtags-windows)
     (rtags-location-stack-push)
     (let ((arg (rtags-current-location))
@@ -1839,7 +1840,7 @@ is true. References to references will be treated as references to the reference
 ;;;###autoload
 (defun rtags-find-all-references-at-point (&optional prefix)
   (interactive "P")
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (rtags-delete-rtags-windows)
     (rtags-location-stack-push)
     (let ((arg (rtags-current-location))
@@ -1853,7 +1854,7 @@ is true. References to references will be treated as references to the reference
 ;;;###autoload
 (defun rtags-guess-function-at-point()
   (interactive)
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (rtags-delete-rtags-windows)
     (rtags-location-stack-push)
     (let ((token (rtags-current-token))
@@ -1879,7 +1880,7 @@ is true. References to references will be treated as references to the reference
 ;;;###autoload
 (defun rtags-rename-symbol ()
   (interactive)
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (save-some-buffers) ;; it all kinda falls apart when buffers are unsaved
     (let* ((prev (let ((token (rtags-current-token)))
                    (cond ((string-match "^~" token) (substring token 1))
@@ -1936,22 +1937,26 @@ is true. References to references will be treated as references to the reference
 ;;;###autoload
 (defun rtags-find-symbol (&optional prefix)
   (interactive "P")
-  (rtags-find-symbols-by-name-internal "Find rsymbol" "-F" (and prefix buffer-file-name)))
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
+    (rtags-find-symbols-by-name-internal "Find rsymbol" "-F" (and prefix buffer-file-name))))
 
 ;;;###autoload
 (defun rtags-find-references (&optional prefix)
   (interactive "P")
-  (rtags-find-symbols-by-name-internal "Find rreferences" "-R" (and prefix buffer-file-name)))
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
+    (rtags-find-symbols-by-name-internal "Find rreferences" "-R" (and prefix buffer-file-name))))
 
 ;;;###autoload
 (defun rtags-find-symbol-current-file ()
   (interactive)
-  (rtags-find-symbol t))
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
+    (rtags-find-symbol t)))
 
 ;;;###autoload
 (defun rtags-find-references-current-file ()
   (interactive)
-  (rtags-find-references t))
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
+    (rtags-find-references t)))
 
 (defun rtags-dir-filter ()
   (concat (substring buffer-file-name 0 (string-match "[^/]*/?$" buffer-file-name)) "[^/]* "))
@@ -1959,12 +1964,14 @@ is true. References to references will be treated as references to the reference
 ;;;###autoload
 (defun rtags-find-symbol-current-dir ()
   (interactive)
-  (rtags-find-symbols-by-name-internal "Find rsymbol" "-F" (rtags-dir-filter) t))
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
+    (rtags-find-symbols-by-name-internal "Find rsymbol" "-F" (rtags-dir-filter) t)))
 
 ;;;###autoload
 (defun rtags-find-references-current-dir ()
   (interactive)
-  (rtags-find-symbols-by-name-internal "Find rreferences" (rtags-dir-filter) t))
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
+    (rtags-find-symbols-by-name-internal "Find rreferences" (rtags-dir-filter) t)))
 
 ;;;###autoload
 (defun rtags-apply-fixit-at-point ()
@@ -2268,7 +2275,7 @@ is true. References to references will be treated as references to the reference
 ;;;###autoload
 (defun rtags-cycle-overlays-on-screen ()
   (interactive)
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (let* ((overlays (rtags-overlays-on-screen))
            (idx (and rtags-highlighted-overlay (let ((i 0)
                                                      (overlay overlays))
@@ -2300,7 +2307,7 @@ is true. References to references will be treated as references to the reference
 ;;;###autoload
 (defun rtags-fix-fixit-at-point ()
   (interactive)
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (let ((current-overlays (overlays-at (point))))
       (while (and current-overlays (not (rtags-fix-fixit-overlay (car current-overlays))))
         (setq current-overlays (cdr current-overlays))))))
@@ -2669,7 +2676,7 @@ is true. References to references will be treated as references to the reference
 ;;;###autoload
 (defun rtags-taglist (&optional dest-window)
   (interactive)
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (unless (buffer-file-name)
       (error "rtags-taglist must be run from a buffer visiting a file"))
     (rtags-delete-rtags-windows)
@@ -2787,7 +2794,7 @@ is true. References to references will be treated as references to the reference
 ;;;###autoload
 (defun rtags-imenu ()
   (interactive)
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (rtags-delete-rtags-windows)
     (rtags-location-stack-push)
     (let* ((fn (buffer-file-name))
@@ -2830,7 +2837,7 @@ is true. References to references will be treated as references to the reference
 ;;;###autoload
 (defun rtags-find-file (&optional prefix tagname)
   (interactive "P")
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (rtags-delete-rtags-windows)
     (rtags-location-stack-push)
     (let ((tagname (rtags-current-symbol t)) prompt input offset line column
@@ -2902,7 +2909,7 @@ is true. References to references will be treated as references to the reference
 ;;;###autoload
 (defun rtags-fixit (&optional ediff buffer)
   (interactive "P")
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (save-some-buffers)
     (unless buffer
       (setq buffer (current-buffer)))
@@ -3068,7 +3075,7 @@ CENTER-WINDOW : if true the target window is centered.
 TRY-DECLARATION-FIRST : first try to find the declaration of the item, then the
 definition."
   (interactive)
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (let ((target (if try-declaration-first
                       (rtags-target-declaration-first)
                     (rtags-target))))
@@ -3094,28 +3101,27 @@ definition."
           (select-window win))))))
 
 (defun rtags-find-symbols-by-name-internal (prompt switch &optional filter regexp-filter)
-  (when (rtags-sandbox-id-matches)
-    (rtags-delete-rtags-windows)
-    (rtags-location-stack-push)
-    (let ((tagname (rtags-current-symbol))
-          (path (buffer-file-name))
-          input)
-      (if (> (length tagname) 0)
-          (setq prompt (concat prompt ": (default: " tagname ") "))
-        (setq prompt (concat prompt ": ")))
-      (if (fboundp 'completing-read-default)
-          (setq input (completing-read-default prompt (function rtags-symbolname-complete) nil nil nil 'rtags-symbol-history))
-        (setq input (completing-read prompt (function rtags-symbolname-complete) nil nil nil 'rtags-symbol-history)))
-      (setq rtags-symbol-history (rtags-remove-last-if-duplicated rtags-symbol-history))
-      (when (not (equal "" input))
-        (setq tagname input))
-      (with-current-buffer (rtags-get-buffer)
-        (rtags-call-rc :path path switch tagname :path-filter filter
-                       :path-filter-regex regexp-filter
-                       (when rtags-wildcard-symbol-names "--wildcard-symbol-names")
-                       (when rtags-symbolnames-case-insensitive "-I"))
-        ;; (setq-local rtags-current-file (or path default-directory))
-        (rtags-handle-results-buffer nil nil path)))))
+  (rtags-delete-rtags-windows)
+  (rtags-location-stack-push)
+  (let ((tagname (rtags-current-symbol))
+        (path (buffer-file-name))
+        input)
+    (if (> (length tagname) 0)
+        (setq prompt (concat prompt ": (default: " tagname ") "))
+      (setq prompt (concat prompt ": ")))
+    (if (fboundp 'completing-read-default)
+        (setq input (completing-read-default prompt (function rtags-symbolname-complete) nil nil nil 'rtags-symbol-history))
+      (setq input (completing-read prompt (function rtags-symbolname-complete) nil nil nil 'rtags-symbol-history)))
+    (setq rtags-symbol-history (rtags-remove-last-if-duplicated rtags-symbol-history))
+    (when (not (equal "" input))
+      (setq tagname input))
+    (with-current-buffer (rtags-get-buffer)
+      (rtags-call-rc :path path switch tagname :path-filter filter
+                     :path-filter-regex regexp-filter
+                     (when rtags-wildcard-symbol-names "--wildcard-symbol-names")
+                     (when rtags-symbolnames-case-insensitive "-I"))
+      ;; (setq-local rtags-current-file (or path default-directory))
+      (rtags-handle-results-buffer nil nil path))))
 
 (defun rtags-symbolname-completion-get (string)
   (with-temp-buffer
@@ -3209,7 +3215,7 @@ definition."
 ;;;###autoload
 (defun rtags-compile-file (&optional buffer)
   (interactive)
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (let ((source (cond ((stringp buffer) buffer)
                         ((bufferp buffer) (buffer-file-name buffer))
                         (t (buffer-file-name)))))
@@ -3344,7 +3350,7 @@ definition."
 (defun rtags-reparse-file (&optional buffer wait-reparsing)
   "WAIT-REPARSING : t to wait for reparsing to finish, nil for async (no waiting)."
   (interactive)
-  (when (and (called-interactively-p) (rtags-sandbox-id-matches))
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (unless buffer
       (setq buffer (current-buffer)))
     (let ((file (buffer-file-name buffer)))
@@ -3490,7 +3496,7 @@ details).
 
 If `rtags-display-summary-as-tooltip' is t, a tooltip is displayed."
   (interactive)
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (let ((summary (rtags-get-summary-text)))
       (when (or summary (not hide-empty))
         (when (null summary)
@@ -3556,7 +3562,7 @@ If `rtags-display-summary-as-tooltip' is t, a tooltip is displayed."
 (defun rtags-get-include-file-for-symbol ()
   "Insert #include declaration to buffer corresponding to the input symbol."
   (interactive)
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (let* ((token (rtags-current-token))
            (prompt (if token
                        (format "Symbol (default: %s): " token)
@@ -3703,7 +3709,7 @@ If `rtags-display-summary-as-tooltip' is t, a tooltip is displayed."
 ;;;###autoload
 (defun rtags-check-includes ()
   (interactive)
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (let ((filename (rtags-untrampify (buffer-file-name))))
       (unless filename
         (error "You need to call rtags-check-includes from an actual file"))
@@ -3726,7 +3732,7 @@ If `rtags-display-summary-as-tooltip' is t, a tooltip is displayed."
 (defun rtags-create-doxygen-comment ()
   "Creates doxygen comment for function at point Comment will be inserted before current line. It uses yasnippet to let the user enter missing field manually."
   (interactive)
-  (when (rtags-sandbox-id-matches)
+  (when (or (not (called-interactively-p)) (rtags-sandbox-id-matches))
     (save-some-buffers) ;; it all kinda falls apart when buffers are unsaved
     (let ((symbol (rtags-symbol-info-internal)))
       (unless symbol


### PR DESCRIPTION
<pre>

1 Contents
==================================

1.1 enhancement #477: let rtags handle the project that sits on remote site.
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


1.2 Baseline: this patch does not touch current functionality, ie. rtags on local host (a.k.a local sandbox) works as before.
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


1.3 `sandbox` term.
~~~~~~~~~~~~~~~~~~~

  Every user@host visited from emacs is a separate sandbox.

  Example:

  user@some.host - user's sandbox on some.host. su:: - root on local
  machine sandbox. sudo:: - root on local machine sandbox.
  local sandbox  - when emacs starts it falls into this sandbox.


1.4 how to use new functionality.
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  1) install rc/rdm on remote sandbox. (this also affects su::/sudo::).
  2) start rdm on remote sandbox. (this also affects su::/sudo::).
  3) run emacs.
  4) compile project on remote sandbox using rtags instrumentation.
  5) make sure that path to rc on remote host is in Your
     tramp-remote-path variable.
  6) (setq password-cache-expiry nil)  ;; helps alot.
  7) (setq rtags-tramp-enabled t)
  8) visit some project file and use rtags on that.


1.5 tests.
~~~~~~~~~~

  All C-cr commands have been tested and are *EXPECTED* to work in
  either of scenarios:
  1) local sandbox
  2) remote host (ssh family) sandbox
  3) su::/sudo:: sandbox


1.6 multiple sandboxes in the same emacs session.
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  Yes, it is possible, ie You can visit files that belong to two or more
  sandboxes.

  How rtags handles it? rtags query goes to that rc/rdm
  backend that sits on the same sandbox current file is from.


1.6.1 How about diagnostics process?
------------------------------------

  1. Diagnostics is not running.
  All goes transparent.

  1. Diagnostics is running.
  Those C-cr * commands that make query to rc/rdm, do the check if
  another sandbox is going to be used. If yes, then the prompt for
  changing the sandbox appears. When confirmed, diagnostics process on
  current sandbox is stopped, then started on new sandbox. Now please
  run Your command once more.


1.6.2 Although sandboxes intermixing is possible, I'd rather suggest to work with each sandbox with separate emacs process.
---------------------------------------------------------------------------------------------------------------------------


1.7 rdm backend managing for non-local sandboxes directly from rtags.
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  It is not yet done, ie. for local sandbox it works as previously, but
  for non-local sandboxes I start and stop rdm by hand.


1.8 Known issues.
~~~~~~~~~~~~~~~~~

  1) non-local sandboxes case only: when going through location stack
     with C-cr [ or ], then repeating the last command with either [ or
     ], the command is *sometimes* canceled, and I end up with
     additional '[' or ']' pressed into the buffer. It happens when
     helm-org package has been evaluated. Problem has been isolated and
     is so far reported [here]. It has nothing common with rtags.

     Reason: post-command-hook invokes rtags-update-current-project,
     which in turn invokes start-file-process after 0.5s. This makes
     repeating is canceled.

     Workaround:
     * set rtags-update-current-project-timer-interval to somewhat
       larger value, (for example 3secs), thus You'll have more time to
       repeat to next location, or
     * don't evaluate helm-org

  2) non-local sandboxes case only: (happened only once) when repeating
     through location stack with C-cr [ or ], traversing is stuck at
     some location, ie. I cannot go either forward or backward.

     Reason:
     it is because nil location has somehow been stored into
     rtags-location-stack, so subsequent visit of such location causes
     traversal to stuck. As I'll meet the problem in the future I'll fix
     it.

     Workaround: none.


  [here] https://github.com/emacs-helm/helm/issues/1299


1.9 TODO.
~~~~~~~~~

  1. consider starting as many diagnostic processes as there are opened
     sandboxes. Maybe it makes sense maybe not.
  2. handle rtags-set-current-project.
  3. let rtags start/stop rdm also on remote sandboxes.
  4. When more and more tests are performed, remove rtags-tramp-enabled
     fuse.

</pre>