### PR TITLE
Fix #551: "fatal error: '/some/path' file not found" when -iquote is used.

### DIFF
--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -538,7 +538,7 @@ List<Source> Source::parse(const String &cmdLine,
             } else if (arg.startsWith("-isystem")) {
                 addIncludeArg(includePaths, Source::Include::Type_System, 8, split, i, path);
             } else if (arg.startsWith("-iquote")) {
-                addIncludeArg(includePaths, Source::Include::Type_FileInclude, 7, split, i, path);
+                addIncludeArg(includePaths, Source::Include::Type_Quote, 7, split, i, path);
             } else if (arg.startsWith("-cxx-isystem")) {
                 addIncludeArg(includePaths, Source::Include::Type_System, 12, split, i, path);
             } else if (arg == "-ObjC++") {
@@ -840,6 +840,9 @@ List<String> Source::toCommandLine(Flags<CommandLineFlag> flags, bool *usedPch) 
             case Source::Include::Type_Include:
                 ret << ("-I" + inc.path);
                 break;
+            case Source::Include::Type_Quote:
+                ret << ("-iquote" + inc.path);
+                break;
             case Source::Include::Type_Framework:
                 ret << ("-F" + inc.path);
                 break;
@@ -870,6 +873,9 @@ List<String> Source::toCommandLine(Flags<CommandLineFlag> flags, bool *usedPch) 
                     assert(0 && "Impossible impossibility");
                     break;
                 case Source::Include::Type_Include:
+                    ret << ("-I" + inc.path);
+                    break;
+                case Source::Include::Type_Quote:
                     ret << ("-I" + inc.path);
                     break;
                 case Source::Include::Type_Framework:
@@ -908,4 +914,3 @@ bool Source::Include::isPch() const
     }
     return false;
 }
-

--- a/src/Source.h
+++ b/src/Source.h
@@ -99,6 +99,7 @@ struct Source
         enum Type {
             Type_None,
             Type_Include,
+            Type_Quote,
             Type_Framework,
             Type_System,
             Type_SystemFramework,
@@ -116,6 +117,7 @@ struct Source
         {
             switch (type) {
             case Type_Include: return String::format<128>("-I%s", path.constData());
+            case Type_Quote: return String::format<128>("-iquote %s", path.constData());
             case Type_Framework: return String::format<128>("-F%s", path.constData());
             case Type_System: return String::format<128>("-isystem %s", path.constData());
             case Type_SystemFramework: return String::format<128>("-iframework %s", path.constData());


### PR DESCRIPTION
"iquote" compilation arguments (which add a directory to the search path) were
being treated as if they were "include" (which implicitly includes a file). This
commit fixes that.