### PR TITLE
Quick and dirty solution for escaping briefComment.

### DIFF
--- a/src/QueryJob.cpp
+++ b/src/QueryJob.cpp
@@ -347,7 +347,7 @@ bool QueryJob::write(const Symbol &symbol,
                 elisp(out, "type", symbol.type, flags | Quote);
             }
             elisp(out, "linkage", symbol.linkage, flags | Quote);
-            elisp(out, "briefComment", symbol.briefComment, flags | ElispEscape);
+            elisp(out, "briefComment", symbol.briefComment + " ", flags | ElispEscape);
             elisp(out, "xmlComment", symbol.xmlComment, flags | ElispEscape);
             elisp(out, "startLine", symbol.startLine, flags);
             elisp(out, "startColumn", symbol.startColumn, flags);


### PR DESCRIPTION
M-x rtags-find-symbol used to fail with: Invalid read syntax: "#"
when looking up a symbol in a function with a carefully crafted comment 
that contained a backslash.
The problem is with briefComment: in some cases its rightmost character
is a backslash if the function's comment is strange enough.
This causes rdm to generate this elisp: (cons 'briefComment "...\"),
which accidentally escapes the right double-quotes, leading to bad lisp.
A proper solution would be to properly escape the briefComment string.
The current patch adds a single whitespace at the end of the briefComment
string, making sure that the right double-quotes do not get escaped.

An example code that reproduces the error:
(If we place the cursor on var and try to rtags-find-symbol)

/*********\
 Comments
\*********/
int foo() {
  int var;
}

Before the patch rdm used to generate this:
(cons 'briefComment "*********\")
After the patch it generates this:
(cons 'briefComment "*********\ ")