### PR TITLE
Add support for building on Windows under msys2.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,12 @@ set(CMAKE_SKIP_BUILD_RPATH            FALSE)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH    FALSE)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
+# Treat MSYS as Cygwin
+if (MSYS)
+    set(CYGWIN 1)
+    set(CMAKE_SYSTEM_NAME "CYGWIN")
+endif ()
+
 # Set RPATH when installing to a custom (non-system) directory
 list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
 if ("${isSystemDir}" STREQUAL "-1")


### PR DESCRIPTION
Msys(2) is basically the same as Cygwin, just under a different name. If we treat it as Cygwin everything just works (tm).

Tested on Msys2 + 64-bit Windows 10 with:
```
mkdir build && cd build
cmake ..
make
make install
```

We do get some extra warnings in FIleSystemWatcher_win32.cpp, due to msys2 seemingly defining DWORD as unsigned int instead of unsigned long but I haven't looked into it further.
Note that I needed to work around #560 for make install to work, and required my fix in Andersbakken/rct#46 for it to build.