### PR TITLE
fix #587: helm better support for rtags-find-* family of functions

### DIFF
--- a/src/rtags.el
+++ b/src/rtags.el
@@ -3190,6 +3190,8 @@ definition."
           (recenter-top-bottom (when (not center-window) 0))
           (select-window win))))))
 
+(defvar rtags-helm-find-symbol-min-input 4)
+
 (defun rtags-find-symbols-by-name-internal (prompt switch &optional filter regexp-filter other-window)
   (rtags-delete-rtags-windows)
   (rtags-location-stack-push)
@@ -3199,9 +3201,14 @@ definition."
     (if (> (length tagname) 0)
         (setq prompt (concat prompt ": (default: " tagname ") "))
       (setq prompt (concat prompt ": ")))
-    (if (fboundp 'completing-read-default)
-        (setq input (completing-read-default prompt (function rtags-symbolname-complete) nil nil nil 'rtags-symbol-history))
-      (setq input (completing-read prompt (function rtags-symbolname-complete) nil nil nil 'rtags-symbol-history)))
+    (if rtags-use-helm
+        (setq input (helm-comp-read prompt (function rtags-symbolname-complete)
+                                    :fuzzy nil
+                                    :requires-pattern rtags-helm-find-symbol-min-input
+                                    :input-history rtags-symbol-history))
+      (if (fboundp 'completing-read-default)
+          (setq input (completing-read-default prompt (function rtags-symbolname-complete) nil nil nil 'rtags-symbol-history))
+        (setq input (completing-read prompt (function rtags-symbolname-complete) nil nil nil 'rtags-symbol-history))))
     (setq rtags-symbol-history (rtags-remove-last-if-duplicated rtags-symbol-history))
     (when (not (equal "" input))
       (setq tagname input))

--- a/src/rtags.el
+++ b/src/rtags.el
@@ -3205,7 +3205,8 @@ definition."
         (setq input (helm-comp-read prompt (function rtags-symbolname-complete)
                                     :fuzzy nil
                                     :requires-pattern rtags-helm-find-symbol-min-input
-                                    :input-history rtags-symbol-history))
+                                    :input-history rtags-symbol-history
+                                    :default tagname))
       (if (fboundp 'completing-read-default)
           (setq input (completing-read-default prompt (function rtags-symbolname-complete) nil nil nil 'rtags-symbol-history))
         (setq input (completing-read prompt (function rtags-symbolname-complete) nil nil nil 'rtags-symbol-history))))

--- a/src/rtags.el
+++ b/src/rtags.el
@@ -3190,7 +3190,7 @@ definition."
           (recenter-top-bottom (when (not center-window) 0))
           (select-window win))))))
 
-(defvar rtags-helm-find-symbol-min-input 4)
+(defvar rtags-helm-find-symbol-min-input 2)
 
 (defun rtags-find-symbols-by-name-internal (prompt switch &optional filter regexp-filter other-window)
   (rtags-delete-rtags-windows)


### PR DESCRIPTION
Fix aims in all 3 points mentioned in #587.

For this fix to work correctly, there is a work in progress in helm module, which needs to be used.

https://github.com/emacs-helm/helm/issues/1366

Thierry provided a patch I've used during testing. The patch is NOT yet put to master@helm.

When it's done I'll give a note to this pull request.

regards