### PR TITLE
`rtags-location-stack-push' enriched with optional loc-arg argument.

### DIFF
--- a/src/rtags.el
+++ b/src/rtags.el
@@ -1701,8 +1701,11 @@ Can be used both for path and location."
 (defvar rtags-location-stack-index 0)
 (defvar rtags-location-stack nil)
 
-(defun rtags-location-stack-push ()
-  (let ((bm (rtags-current-location)))
+(defun rtags-location-stack-push (&optional loc-arg)
+  "Push current location into location stack.
+If loc-arg is non-nil, then push it instead.
+See `rtags-current-location' for loc-arg format."
+  (let ((bm (or loc-arg (rtags-current-location))))
     (while (> rtags-location-stack-index 0)
       (decf rtags-location-stack-index)
       (pop rtags-location-stack))


### PR DESCRIPTION
why needed?

after rtags didn't find the desired location, some more primitive fallback mechanism can alternativelly be used.

It is good that this alternative mechanism could store both the locations found on rtags location stack.

'Both' means:
source (just before search) and destination (just after search) location.

I cannot just always/uncoditionally store source location, because what if search process fails or is cancelled during processing? I would end up with source location without destination location on the stack.

thanks to this additional parameter I can store source location only when search succeeded thus I end up in destination location.