### PR TITLE
start rdm server in emacs

### DIFF
--- a/src/rtags.el
+++ b/src/rtags.el
@@ -842,6 +842,7 @@ Can be used both for path and location."
           (unless noerror (error "Can't find rc"))
         (setq rtags-last-request-not-connected nil)
         (setq rtags-last-request-not-indexed nil)
+        (rtags-start-process-maybe)
         (when (and async (not (consp async)))
           (error "Invalid argument. async must be a cons or nil"))
         (setq arguments (rtags-remove-keyword-params arguments))


### PR DESCRIPTION
start rdm server at first if possible when calling rtags-call-rc. So I don't need to call it from terminal  or call elisp function every time  when I use rtags