### PR TITLE
Add [Install] to systemd example

### DIFF
--- a/README.org
+++ b/README.org
@@ -368,6 +368,9 @@ can also be socket acivated.
 
    [Socket]
    ListenStream=$HOME/.rdm
+   
+   [Install]
+   WantedBy=multi-user.target
    #+END_EXAMPLE
 
  2. Add the following to =~/.config/systemd/user/rdm.service=


### PR DESCRIPTION
Otherwise, systemctl complains that the unit is "not meant to be enabled".

I'm a systemd noob, so hopefully this is correct! But it seems to work for me.