### PR TITLE
Added relative sandbox path support for index db files save and load

### DIFF
--- a/src/ClangIndexer.cpp
+++ b/src/ClangIndexer.cpp
@@ -31,6 +31,7 @@
 #include "RTags.h"
 #include "VisitFileMessage.h"
 #include "VisitFileResponseMessage.h"
+#include "Location.h"
 
 const CXSourceLocation ClangIndexer::nullLocation = clang_getNullLocation();
 const CXCursor ClangIndexer::nullCursor = clang_getNullCursor();
@@ -67,7 +68,7 @@ struct VerboseVisitorUserData {
 };
 
 Flags<Server::Option> ClangIndexer::sServerOpts;
-Path ClangIndexer::sServerRoot;
+Path ClangIndexer::sServerSandboxRoot;
 ClangIndexer::ClangIndexer()
     : mClangUnit(0), mIndex(0), mLastCursor(nullCursor), mLastCallExpr(nullCursor),
       mVisitFileResponseMessageFileId(0), mVisitFileResponseMessageVisit(0), mParseDuration(0),
@@ -118,7 +119,7 @@ bool ClangIndexer::exec(const String &data)
     deserializer >> connectAttempts;
     deserializer >> niceValue;
     deserializer >> sServerOpts;
-    deserializer >> sServerRoot;
+    deserializer >> sServerSandboxRoot;
     deserializer >> mUnsavedFiles;
     deserializer >> mDataDir;
     deserializer >> mDebugLocations;
@@ -1733,6 +1734,24 @@ static inline Map<String, Set<Location> > convertTargets(const Map<Location, Map
     return ret;
 }
 
+static void convertRelativePath(Map<String, Set<Location> > & usrs)
+{
+    std::list<String> sbstrs;
+
+    for (auto & m : usrs) {
+        if (Location::containSandboxRoot(m.first)) {
+            sbstrs.push_back(m.first);
+        }
+    }
+    for (auto & n : sbstrs) {
+        auto it = usrs.find(n);
+        assert(it != usrs.end());
+        String srel = Location::replaceFullWithRelativePath(n);
+        std::swap(usrs[srel], it->second);
+        usrs.erase(it);
+    }
+}
+
 bool ClangIndexer::writeFiles(const Path &root, String &error)
 {
     for (const auto &unit : mUnits) {
@@ -1762,14 +1781,21 @@ bool ClangIndexer::writeFiles(const Path &root, String &error)
             error = "Failed to write symbols";
             return false;
         }
-        if (!FileMap<String, Set<Location> >::write(unitRoot + "/targets", convertTargets(unit.second->targets), fileMapOpts)) {
+        Map<String, Set<Location> > tmpTargets = convertTargets(unit.second->targets);
+        // SBROOT
+        convertRelativePath(tmpTargets);
+        if (!FileMap<String, Set<Location> >::write(unitRoot + "/targets", tmpTargets, fileMapOpts)) {
             error = "Failed to write targets";
             return false;
         }
+        // SBROOT
+        convertRelativePath(unit.second->usrs);
         if (!FileMap<String, Set<Location> >::write(unitRoot + "/usrs", unit.second->usrs, fileMapOpts)) {
             error = "Failed to write usrs";
             return false;
         }
+        // SBROOT
+        convertRelativePath(unit.second->symbolNames);
         if (!FileMap<String, Set<Location> >::write(unitRoot + "/symnames", unit.second->symbolNames, fileMapOpts)) {
             error = "Failed to write symbolNames";
             return false;

--- a/src/ClangIndexer.h
+++ b/src/ClangIndexer.h
@@ -39,7 +39,12 @@ public:
 
     bool exec(const String &data);
     static Flags<Server::Option> serverOpts() { return sServerOpts; }
-    static const Path &serverRoot() { return sServerRoot; }
+    static const Path &serverSandboxRoot() { return sServerSandboxRoot; }
+    static void setServerSandboxRoot(const String & s)
+    {
+        sServerSandboxRoot = s;
+    }
+
 private:
     bool diagnose();
     bool visit();
@@ -211,7 +216,7 @@ private:
     List<CXCursor> mParents;
 
     static Flags<Server::Option> sServerOpts;
-    static Path sServerRoot;
+    static Path sServerSandboxRoot;
 };
 
 #endif

--- a/src/Diagnostic.h
+++ b/src/Diagnostic.h
@@ -43,14 +43,19 @@ struct Diagnostic
 
 template <> inline Serializer &operator<<(Serializer &s, const Diagnostic &d)
 {
-    s << static_cast<uint8_t>(d.type) << d.message << d.length << d.ranges << d.children;
+    // SBROOT
+    String tmessage = Location::replaceFullWithRelativePath(d.message);
+    s << static_cast<uint8_t>(d.type) << tmessage << d.length << d.ranges << d.children;
     return s;
 }
 
 template <> inline Deserializer &operator>>(Deserializer &s, Diagnostic &d)
 {
     uint8_t type;
-    s >> type >> d.message >> d.length >> d.ranges >> d.children;
+    String tmessage;
+    s >> type >> tmessage >> d.length >> d.ranges >> d.children;
+    // SBROOT
+    d.message = Location::replaceRelativeWithFullPath(tmessage);
     d.type = static_cast<Diagnostic::Type>(type);
     return s;
 }

--- a/src/IndexerJob.cpp
+++ b/src/IndexerJob.cpp
@@ -141,7 +141,7 @@ String IndexerJob::encode() const
                    << static_cast<uint32_t>(options.rpConnectAttempts)
                    << static_cast<int32_t>(options.rpNiceValue)
                    << options.options
-                   << options.root
+                   << options.sandboxRoot
                    << unsavedFiles
                    << options.dataDir
                    << options.debugLocations;

--- a/src/JobScheduler.cpp
+++ b/src/JobScheduler.cpp
@@ -127,6 +127,12 @@ void JobScheduler::startJobs()
         debug() << "Starting process for" << jobId << node->job->source.key() << node->job.get();
         List<String> arguments;
         arguments << "--priority" << String::number(node->job->priority);
+        
+        // SBROOT
+        if (!options.sandboxRoot.isEmpty()) {
+            arguments << "--sandbox-root" << options.sandboxRoot.constData();
+        }
+        
         for (int i=logLevel().toInt(); i>0; --i)
             arguments << "-v";
 

--- a/src/Location.cpp
+++ b/src/Location.cpp
@@ -19,6 +19,7 @@
 #include "RTags.h"
 #include "Server.h"
 #include "Project.h"
+#include "ClangIndexer.h"
 
 Hash<Path, uint32_t> Location::sPathsToIds;
 Hash<uint32_t, Path> Location::sIdsToPaths;
@@ -122,6 +123,89 @@ String Location::context(Flags<ToStringFlag> flags, Hash<Path, String> *cache) c
         }
     }
     return ret;
+}
+
+const Path &Location::sandboxRoot()
+{
+    if (Server::instance()) {
+        return Server::instance()->options().sandboxRoot;
+    } else {
+        return ClangIndexer::serverSandboxRoot();
+    }
+}
+
+const char *RELSBROOT = "[[SBROOT]]";
+static inline bool pathStartWithRELSBROOT(const Path &path)
+{
+    return (strncmp(path.c_str(), RELSBROOT, strlen(RELSBROOT)) == 0);
+}
+
+bool Location::containRelativePath(const String & str)
+{
+    return (str.indexOf(RELSBROOT) != std::string::npos);
+}
+
+void Location::strPathToSbRoot(Path &path)
+{
+    auto idx = path.indexOf(RELSBROOT);
+    if (idx != std::string::npos) {
+        path.replace(idx, strlen(RELSBROOT), Location::sandboxRoot());
+    }
+}
+
+bool Location::containSandboxRoot(const String & str)
+{
+    if (Location::sandboxRoot().isEmpty()) return false;
+    return (str.indexOf(Location::sandboxRoot()) != std::string::npos);
+}
+
+String Location::replaceRelativeWithFullPath(const String & key)
+{
+    if (!Location::sandboxRoot().isEmpty()) {
+        auto idx = key.indexOf(RELSBROOT);
+        if (idx != std::string::npos) {
+            String keyCpy = key;
+            keyCpy.replace(idx, strlen(RELSBROOT), Location::sandboxRoot());
+            return keyCpy;
+        }
+    }
+    return key;
+}
+
+String Location::replaceFullWithRelativePath(const String & key)
+{
+    if (!Location::sandboxRoot().isEmpty()) {
+        auto idx = key.indexOf(Location::sandboxRoot());
+        if (idx != std::string::npos) {
+            String keyCpy = key;
+            keyCpy.replace(idx, Location::sandboxRoot().size(), RELSBROOT);
+            return keyCpy;
+        }
+    }
+    return key;
+}
+
+void Location::convertPathRelative(Path & path)
+{
+    if (!path.isEmpty() && !pathStartWithRELSBROOT(path)) {
+        // assert(path.isAbsolute());
+        const Path &root = Location::sandboxRoot();
+        if (!root.isEmpty() && path.startsWith(root)) {
+            assert(root.endsWith('/'));
+            path.replace(0, root.size(), RELSBROOT);
+        }
+    }
+}
+
+void Location::convertPathFull(Path &path)
+{
+    if (pathStartWithRELSBROOT(path)) {
+        const Path &root = Location::sandboxRoot();
+        if (!root.isEmpty()) {
+            assert(root.endsWith('/'));
+            path.replace(0, strlen(RELSBROOT), root.c_str());
+        }
+    }
 }
 
 void Location::saveFileIds()

--- a/src/Location.h
+++ b/src/Location.h
@@ -90,6 +90,19 @@ public:
         return sIdsToPaths.size();
     }
 
+    static const Path & sandboxRoot();
+
+    static void strPathToSbRoot(Path &path);
+
+    static void convertPathRelative(Path & path);
+    static void convertPathFull(Path &path);
+    
+    static bool containRelativePath(const String & str);
+    static bool containSandboxRoot(const String & str);
+
+    static String replaceRelativeWithFullPath(const String & key);
+    static String replaceFullWithRelativePath(const String & key);
+
     static inline uint32_t insertFile(const Path &path)
     {
         bool save = false;

--- a/src/RTags.cpp
+++ b/src/RTags.cpp
@@ -45,9 +45,9 @@
 namespace RTags {
 void encodePath(Path &path)
 {
-    const Path &root = Server::instance() ? Server::instance()->options().root : ClangIndexer::serverRoot();
-    if (!root.isEmpty() && path.startsWith(root)) {
-        path.replace(0, root.size(), "$/");
+    // SBROOT
+    if (!Location::sandboxRoot().isEmpty()) {
+        Location::convertPathRelative(path);
     }
     int size = path.size();
     for (int i=0; i<size; ++i) {
@@ -66,13 +66,11 @@ void encodePath(Path &path)
 
 void decodePath(Path &path)
 {
-    int i = 0;
-    if (path.startsWith("$_")) {
-        const Path &root = Server::instance() ? Server::instance()->options().root : ClangIndexer::serverRoot();
-        assert(!root.isEmpty());
-        path.replace(0, 2, root);
-        i = root.size();
+    // SBROOT
+    if (!Location::sandboxRoot().isEmpty()) {
+        Location::strPathToSbRoot(path);
     }
+    int i = 0;
     int size = path.size();
     while (i < size) {
         char &ch = path[i];

--- a/src/Server.h
+++ b/src/Server.h
@@ -91,7 +91,7 @@ public:
         {
         }
 
-        Path socketFile, dataDir, argTransform, rp, root;
+        Path socketFile, dataDir, argTransform, rp, sandboxRoot;
         Flags<Option> options;
         size_t jobCount, headerErrorJobCount, maxIncludeCompletionDepth;
         int rpVisitFileTimeout, rpIndexDataMessageTimeout,
@@ -131,7 +131,7 @@ public:
                Set<uint64_t> *indexed = 0);
     enum FileIdsFileFlag {
         None = 0x0,
-        HasRoot = 0x1
+        HasSandboxRoot = 0x1
     };
 private:
     String guessArguments(const String &args, const Path &pwd, const Path &projectRootOverride);

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -919,3 +919,21 @@ bool Source::Include::isPch() const
     }
     return false;
 }
+
+void Source::convertIncludePathsRelative(List<Include> & tincludePaths)
+{
+    for (auto & m : tincludePaths) {
+        if (!m.path.isEmpty()) {
+            Location::convertPathRelative(m.path);
+        }
+    }
+}
+
+void Source::convertIncludePathsFull(List<Include> & tincludePaths)
+{
+    for (auto & m : tincludePaths) {
+        if (!m.path.isEmpty()) {
+            Location::convertPathFull(m.path);
+        }
+    }
+}

--- a/src/Source.h
+++ b/src/Source.h
@@ -186,6 +186,8 @@ struct Source
                               const Path &pwd,
                               const List<Path> &pathEnvironment,
                               List<Path> *unresolvedInputLocation = 0);
+    static void convertIncludePathsRelative(List<Include> & tincludePaths);
+    static void convertIncludePathsFull(List<Include> & tincludePaths);
 };
 
 RCT_FLAGS(Source::Flag);
@@ -325,10 +327,27 @@ template <> inline Deserializer &operator>>(Deserializer &s, Source::Include &d)
 
 template <> inline Serializer &operator<<(Serializer &s, const Source &b)
 {
-    s << b.sourceFile() << b.fileId << b.compiler() << b.compilerId
-      << b.extraCompiler << b.buildRoot() << b.buildRootId
+    // SBROOT
+    // sourceFile, buildRoot, compiler(?), includePaths
+    Path tsourceFile = b.sourceFile();
+    Location::convertPathRelative(tsourceFile);
+    Path tbuildRoot = b.buildRoot();
+    Location::convertPathRelative(tbuildRoot);
+
+    List<Source::Include> tincludePaths = b.includePaths;
+    Source::convertIncludePathsRelative(tincludePaths);
+
+    Path tcompiler = b.compiler();
+    Location::convertPathRelative(tcompiler);
+    Path textraCompiler = b.extraCompiler;
+    Location::convertPathRelative(textraCompiler);
+    Path tdirectory = b.directory;
+    Location::convertPathRelative(tdirectory);
+     
+    s << tsourceFile << b.fileId << b.compiler() << b.compilerId
+      << b.extraCompiler << tbuildRoot << b.buildRootId
       << static_cast<uint8_t>(b.language) << b.parsed << b.flags << b.defines
-      << b.includePaths << b.arguments << b.sysRootIndex << b.directory << b.includePathHash;
+      << tincludePaths << b.arguments << b.sysRootIndex << tdirectory << b.includePathHash;
     return s;
 }
 
@@ -341,6 +360,17 @@ template <> inline Deserializer &operator>>(Deserializer &s, Source &b)
       >> buildRoot >> b.buildRootId >> language >> b.parsed >> b.flags
       >> b.defines >> b.includePaths >> b.arguments >> b.sysRootIndex
       >> b.directory >> b.includePathHash;
+
+    // SBROOT
+    Location::convertPathFull(source);
+    Location::convertPathFull(buildRoot);
+    Location::convertPathFull(compiler);
+    Location::convertPathFull(b.extraCompiler);
+    Location::convertPathFull(b.directory);
+    
+    Source::convertIncludePathsFull(b.includePaths);
+
+    
     Location::set(source, b.fileId);
     Location::set(compiler, b.compilerId);
     Location::set(buildRoot, b.buildRootId);

--- a/src/Symbol.h
+++ b/src/Symbol.h
@@ -139,9 +139,17 @@ RCT_FLAGS(Symbol::ToStringFlag);
 
 template <> inline Serializer &operator<<(Serializer &s, const Symbol &t)
 {
-    s << t.location << t.symbolName << t.usr << t.typeName << t.baseClasses << t.arguments
+    // SBROOT -- need to find and replace to relative path
+    //     symbolName, usr, briefComment, xmlComment
+    String tsymbolName = Location::replaceFullWithRelativePath(t.symbolName);
+    String tusr = Location::replaceFullWithRelativePath(t.usr);
+    String ttypeName = Location::replaceFullWithRelativePath(t.typeName);
+    String tbriefComment = Location::replaceFullWithRelativePath(t.briefComment);
+    String txmlComment = Location::replaceFullWithRelativePath(t.xmlComment);
+    
+    s << t.location << tsymbolName << tusr << ttypeName << t.baseClasses << t.arguments
       << t.symbolLength << static_cast<uint16_t>(t.kind) << static_cast<uint16_t>(t.type)
-      << static_cast<uint8_t>(t.linkage) << t.flags << t.briefComment << t.xmlComment
+      << static_cast<uint8_t>(t.linkage) << t.flags << tbriefComment << txmlComment
       << t.enumValue << t.startLine << t.endLine << t.startColumn << t.endColumn
       << t.size << t.fieldOffset << t.alignment;
     return s;
@@ -151,11 +159,18 @@ template <> inline Deserializer &operator>>(Deserializer &s, Symbol &t)
 {
     uint16_t kind, type;
     uint8_t linkage;
+    // SBROOT -- need to find and replace to full path
     s >> t.location >> t.symbolName >> t.usr >> t.typeName >> t.baseClasses
       >> t.arguments >> t.symbolLength >> kind >> type >> linkage >> t.flags
       >> t.briefComment >> t.xmlComment >> t.enumValue
       >> t.startLine >> t.endLine >> t.startColumn >> t.endColumn
       >> t.size >> t.fieldOffset >> t.alignment;
+
+    t.symbolName = Location::replaceRelativeWithFullPath(t.symbolName);
+    t.usr = Location::replaceRelativeWithFullPath(t.usr);
+    t.typeName = Location::replaceRelativeWithFullPath(t.typeName);
+    t.briefComment = Location::replaceRelativeWithFullPath(t.briefComment);
+    t.xmlComment = Location::replaceRelativeWithFullPath(t.xmlComment);
 
     t.kind = static_cast<CXCursorKind>(kind);
     t.type = static_cast<CXTypeKind>(type);

--- a/src/rdm.cpp
+++ b/src/rdm.cpp
@@ -145,7 +145,7 @@ static void usage(FILE *f)
             "  --log-file-log-level [arg]                 Log level for log file (default is error).\n"
             "  --crash-dump-file [arg]                    File to dump crash log to (default is <datadir>/crash.dump).\n"
             "                                             options are: error, warning, debug or verbose-debug.\n"
-            "  --root [arg]                               Root to use for paths.\n" // ### need better docs
+            " --sandbox-root dir                          Create index using relative path by stripping dir (enables copying of tag index db files without need to reindexing)\n"
 #ifndef OS_FreeBSD
 #endif
             "  --no-filesystem-watcher|-B                 Disable file system watching altogether. Reindexing has to happen manually.\n"
@@ -312,7 +312,7 @@ int main(int argc, char** argv)
         { "tcp-port", required_argument, 0, 12 },
         { "rp-path", required_argument, 0, 17 },
         { "log-timestamp", no_argument, 0, 18 },
-        { "root", required_argument, 0, 20 },
+        { "sandbox-root", required_argument, 0, 20 },
         { 0, 0, 0, 0 }
     };
     const String shortOptions = Rct::shortOptions(opts);
@@ -510,10 +510,19 @@ int main(int argc, char** argv)
             strcpy(crashDumpFilePath, optarg);
             break;
         case 20:
-            serverOpts.root = optarg;
-            if (!serverOpts.root.resolve() || !serverOpts.root.isDir()) {
-                fprintf(stderr, "%s is not a directory\n", optarg);
-                return 1;
+            {
+                auto len = strlen(optarg);
+                if (optarg[len-1] != '/') {
+                    std::string tmparg = optarg;
+                    tmparg += '/';
+                    serverOpts.sandboxRoot = tmparg.c_str();
+                } else {
+                    serverOpts.sandboxRoot = optarg;
+                }
+                if (!serverOpts.sandboxRoot.resolve() || !serverOpts.sandboxRoot.isDir()) {
+                    fprintf(stderr, "%s is not a valid directory for sandbox-root\n", optarg);
+                    return 1;
+                }
             }
             break;
         case 2:

--- a/src/rp.cpp
+++ b/src/rp.cpp
@@ -60,14 +60,26 @@ int main(int argc, char **argv)
 {
     LogLevel logLevel = LogLevel::Error;
     Path file;
+    String sbroot;
+
     for (int i=1; i<argc; ++i) {
         if (!strcmp(argv[i], "-v") || !strcmp(argv[i], "--verbose")) {
             ++logLevel;
         } else if (!strcmp(argv[i], "--priority")) { // ignore, only for wrapping purposes
             ++i;
+        } else if (!strcmp(argv[i], "--sandbox-root")) { 
+            // SBROOT
+            ++i;
+            sbroot = argv[i];
+            ++i;
         } else {
             file = argv[i];
         }
+    } 
+    
+    // SBROOT
+    if (ClangIndexer::serverSandboxRoot().isEmpty()) {
+        ClangIndexer::setServerSandboxRoot(sbroot);
     }
 
     setenv("LIBCLANG_NOTHREADS", "1", 0);


### PR DESCRIPTION
rdm --sandbox-root=/path/to/mysb ...
Index db files will be saved using relative path by replacing
"/path/to/mysb" with a special token [[SBROOT]] . When index db files are loaded, the special token [[SBROOT]] is then replaced with the current sandbox root path. 

The classes/objects/fields that need this two-way replacements are: File-to-ID mapping, Symbol, Location, Diagnostic, Source, Usr, xmlComment, briefComment, SymbolName, Target, Project, etc.

Added an optional argument --sandbox-root for rdm command. This argument defaults to empty, which will not do relative path replacement.

This enables copying index db files over to a new sandbox without need to reindex.