### PR TITLE
fix e2ba2be4a78d4e0f1d23651b34c627ee2ae88a19

### DIFF
--- a/src/ListSymbolsJob.h
+++ b/src/ListSymbolsJob.h
@@ -39,6 +39,7 @@ protected:
             case CXCursor_InclusionDirective:
             case CXCursor_EnumConstantDecl:
             case CXCursor_StringLiteral:
+            case CXCursor_CXXBoolLiteralExpr:
             case CXCursor_IntegerLiteral:
             case CXCursor_FloatingLiteral:
             case CXCursor_ImaginaryLiteral:


### PR DESCRIPTION
missing CXXBoolLiteralExpr case