### PR TITLE
Use correct member name.

### DIFF
--- a/src/ClangIndexer.cpp
+++ b/src/ClangIndexer.cpp
@@ -1095,7 +1095,7 @@ bool ClangIndexer::handleReference(const CXCursor &cursor, CXCursorKind kind, Lo
         const CXType type = clang_getCursorType(ref);
         if (type.kind != CXType_LValueReference
             && type.kind != CXType_RValueReference
-            && type.type != CXType_Auto
+            && type.kind != CXType_Auto
             && type.kind != CXType_Unexposed) {
             c->size = clang_Type_getSizeOf(type);
             c->alignment = std::max<int16_t>(-1, clang_Type_getAlignOf(type));


### PR DESCRIPTION
`CXType` exposes a `CXTypeKind` `kind`, not `type`.

This was introduced in `0a7cc6bb`.

This fixes #732.