### PR TITLE
Use the doxygen brief to show company's doc-buffer

### DIFF
--- a/src/CompletionThread.cpp
+++ b/src/CompletionThread.cpp
@@ -598,10 +598,11 @@ void CompletionThread::printCompletions(const List<Completions::Candidate> &comp
             }
             if (elisp) {
                 // elispOut += String::format<128>(" (list \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\")",
-                elispOut += String::format<128>(" (list \"%s\" \"%s\" \"%s\")",
+                elispOut += String::format<128>(" (list \"%s\" \"%s\" \"%s\" \"%s\")",
                                                 RTags::elispEscape(val.completion).constData(),
                                                 RTags::elispEscape(val.signature).constData(),
-                                                kind.constData());
+                                                kind.constData(),
+                                                RTags::elispEscape(val.briefComment).constData());
                 //,
                 // RTags::elispEscape(val.annotation).constData(),
                 // val.parent.constData(),


### PR DESCRIPTION
Ideally, this would pass the complete documentation to Emacs, but AFAICT that is not included in clangs completions.

Fixes #633.