### PR TITLE
Update README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -31,7 +31,7 @@ Build RTags
 #+BEGIN_SRC sh
 git clone --recursive https://github.com/Andersbakken/rtags.git
 cd rtags
-cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 .
+cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1  -DRTAGS_NO_BUILD_CLANG=1 .
 make
 #+END_SRC
 


### PR DESCRIPTION
TLDR Quickstart procedure should not by default download clang and compile it.