### PR TITLE
Save database only when all jobs are finished.

### DIFF
--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -750,8 +750,8 @@ void Project::onJobFinished(const std::shared_ptr<IndexerJob> &job, const std::s
                   LogOutput::StdOut|LogOutput::TrailingNewLine);
     }
 
-    save();
     if (mActiveJobs.isEmpty()) {
+        save();
         double timerElapsed = (mTimer.elapsed() / 1000.0);
         const double averageJobTime = timerElapsed / mJobsStarted;
         const String m = String::format<1024>("Jobs took %.2fs%s. We're using %lldmb of memory. ",


### PR DESCRIPTION
It appears that saving each time a job finishes hinders scalability with respect to number of files in a project, in 2 user-noticeable ways:
- rc queries are extremely slow until the project is indexed.
- indexing the project takes a long time.

Specifically, for chromium, rc (and therefore, emacs) are unusable until indexing finishes, because the rc query takes many tens of seconds / close to a minute; and indexing takes ~5 hrs.

This change makes rc responsive almost immediately once rdm starts, and indexing chromium takes about half an hour.