### PR TITLE
Fix a completions result crash in vsnprintf

### DIFF
--- a/src/CompletionThread.cpp
+++ b/src/CompletionThread.cpp
@@ -453,7 +453,7 @@ struct Output
             connection->write(string);
             connection->finish();
         } else {
-            output->log(string.constData(), string.size());
+            output->log(string.constData());
         }
     }
     std::shared_ptr<LogOutput> output;


### PR DESCRIPTION
Ran into a crash after loading a large project and trying a global namespace completion.  The callstack looked something like:

vsnprintf_internal_*
vsnprintf
Log.h:89
Output::send(const String& string)  CompletionThread.cpp:456 

            output->log(string.constData(), string.size());

I wonder if the extra `string.size()` parameter wasn't a typo?  It looks like the string is already formatted and there shouldn't be any extra parameters.

When I removed it and recompiled the crash disappeared.  However, I confess that I added it back later right before submitting this PR (to copy/paste the exact stack from gdb), but I was unable to reproduce the crash again.

Please take a peek though.  Thanks!