### PR TITLE
Really parse -ofoo.o and -o foo.o

### DIFF
--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -636,7 +636,7 @@ List<Source> Source::parse(const String &cmdLine,
                 }
                 if (!p.isEmpty()) {
                     bool ok;
-                    p = Path::resolved(split.value(++i), Path::RealPath, path, &ok);
+                    p = Path::resolved(p, Path::RealPath, path, &ok);
                     // error() << p << ok << split.value(i) << Path::resolved(split.value(i), Path::MakeAbsolute);
                     if (!ok && !p.isAbsolute()) {
                         p.prepend(path); // the object file might not exist


### PR DESCRIPTION
This commit unbreaks -o foo.o because in this case , i was incremented
twice, once in the else if and once in the call to Path::resolved.