### PR TITLE
Fix using project index when switching projects

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -1450,26 +1450,27 @@ void Server::project(const std::shared_ptr<QueryMessage> &query, const std::shar
         if (it != mProjects.end()) {
             selected = it->second;
         } else {
-            for (const auto &pit : mProjects) {
-                assert(pit.second);
-                if (ok) {
-                    if (!index) {
-                        selected = pit.second;
-                    } else {
-                        --index;
-                    }
+            if (ok) {
+                if (index < mProjects.size()) {
+                    selected = std::next(mProjects.cbegin(), index)->second;
+                    assert(selected);
                 }
-                if (pit.second->match(match)) {
-                    if (error) {
-                        conn->write(pit.first);
-                    } else if (selected) {
-                        error = true;
-                        conn->write<128>("Multiple matches for %s", match.pattern().constData());
-                        conn->write(selected->path());
-                        conn->write(pit.first);
-                        selected.reset();
-                    } else {
-                        selected = pit.second;
+            }
+            if (!selected) {
+                for (const auto &pit : mProjects) {
+                    assert(pit.second);
+                    if (pit.second->match(match)) {
+                        if (error) {
+                            conn->write(pit.first);
+                        } else if (selected) {
+                            error = true;
+                            conn->write<128>("Multiple matches for %s", match.pattern().constData());
+                            conn->write(selected->path());
+                            conn->write(pit.first);
+                            selected.reset();
+                        } else {
+                            selected = pit.second;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Instead of trying to match by both index and pattern, here index is preferred if numeric value was given. In case of no match still fall back to treating numeric value as a pattern.

This fixes issue #849 