### PR TITLE
Update WantedBy target for user systemd

### DIFF
--- a/README.org
+++ b/README.org
@@ -501,7 +501,7 @@ also be socket acivated.
    ListenStream=%h/.rdm
 
    [Install]
-   WantedBy=multi-user.target
+   WantedBy=default.target
    #+END_EXAMPLE
 
  2. Add the following to =~/.config/systemd/user/rdm.service=


### PR DESCRIPTION
multi-user.target does not exist in the systemd user context, so using
this example the socket won't be started automatically on boot.  See
also
https://unix.stackexchange.com/questions/251211/why-doesnt-my-systemd-user-unit-start-at-boot