### PR TITLE
Update example rdm.service in README to use --log-flush

### DIFF
--- a/README.org
+++ b/README.org
@@ -514,7 +514,7 @@ also be socket acivated.
 
    [Service]
    Type=simple
-   ExecStart=$RDM -v --inactivity-timeout 300
+   ExecStart=$RDM -v --inactivity-timeout 300 --log-flush
    #+END_EXAMPLE
 
  3. Replace =$RDM= with the path to your copy of =rdm=, and add any command


### PR DESCRIPTION
The --log-flush option was added in #842 to be more friendly to systemd's default log capture. This commit updates the example rdm.service file to take advantage of the flag.