### PR TITLE
Update example rdm.socket file to new location

### DIFF
--- a/README.org
+++ b/README.org
@@ -498,7 +498,7 @@ also be socket acivated.
    Description=RTags daemon socket
 
    [Socket]
-   ListenStream=%h/.rdm
+   ListenStream=%t/rdm.socket
 
    [Install]
    WantedBy=default.target


### PR DESCRIPTION
As of 193920c0cd71a0d4874c688918e2a1a0f7ff0968 the default socket path is under $XDG_RUNTIME_DIR, which is %t in systemd unit files.