### PR TITLE
Fix two places where `rtags-handle-results-buffer' should be called w…

### DIFF
--- a/src/rtags.el
+++ b/src/rtags.el
@@ -1976,7 +1976,7 @@ instead of file from `current-buffer'.
         (goto-char (point-min))
         (insert "Functions called from: " (cdr (assoc 'location container)) " " (cdr (assoc 'symbolName container)) "\n")
         (goto-char (point-min))
-        (rtags-handle-results-buffer)))))
+        (rtags-handle-results-buffer nil nil file)))))
 
 ;;;###autoload
 (defun rtags-find-all-functions-called-this-function ()
@@ -2416,7 +2416,7 @@ If called with prefix, open first match in other window"
                  (with-current-buffer (rtags-get-buffer)
                    (insert (car results))
                    (goto-char (point-min))
-                   (rtags-handle-results-buffer)))))))))
+                   (rtags-handle-results-buffer nil nil fn otherwindow)))))))))
 
 ;;;###autoload
 (defun rtags-find-references-at-point (&optional prefix)


### PR DESCRIPTION
Fix two places where `rtags-handle-results-buffer` should be called with `path` argument

The affected commands are `rtags-find-functions-called-by-this-function` and `rtags-find-symbol-at-point`. Passing the `path` argument in these two cases are necessary because otherwise the function `rtags-handle-results-buffer` will not be able to find the project root when it calls `rtags-find-project-root` by passing nil as `path` argument.