### PR TITLE
Add -fno-enforce-eh-specs to blacklist

### DIFF
--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -225,6 +225,7 @@ static const char *blacklist[] = {
     "-fno-use-linker-plugin"
     "-fno-var-tracking",
     "-fno-var-tracking-assignments",
+    "-fno-enforce-eh-specs",
     "-fvar-tracking",
     "-fvar-tracking-assignments",
     "-fvar-tracking-assignments-toggle",


### PR DESCRIPTION
This is still unsupported in clang.