### PR TITLE
Add atom-rtags-plus to list of rtags plugins

### DIFF
--- a/README.org
+++ b/README.org
@@ -570,7 +570,7 @@ Vim: https://github.com/lyuts/vim-rtags and https://github.com/shaneharper/vim-r
 
 Sublime Text: https://github.com/rampage644/sublime-rtags
 
-Atom: https://github.com/artagnon/atomic-rtags and https://github.com/rajendrant/atom-rtags
+Atom: https://github.com/artagnon/atomic-rtags, https://github.com/rajendrant/atom-rtags and https://github.com/sphaerophoria/atom-rtags-plus
 
 =rc= has a vast number of commands and options and we intend to write a man
 page at some point. Most users will have limited interest in ever calling them


### PR DESCRIPTION
I've been working on an atom plugin for a bit and think it's gotten to the point where I'm willing to recommend it to others. If you think it looks sufficient would you mind adding it to your list of plugins?