### PR TITLE
Clear chunks when reusing a node.

### DIFF
--- a/src/CompletionThread.cpp
+++ b/src/CompletionThread.cpp
@@ -396,6 +396,7 @@ void CompletionThread::process(Request *request)
             }
             node.completion.clear();
             node.signature.clear();
+            node.chunks.clear();
         }
         if (nodeCount) {
             // Sort pointers instead of shuffling candidates around


### PR DESCRIPTION
This prevents chunks from a previous completion being erroneously returned as
part of some other unrelated completion.

I'm writing an rtags plugin for Visual Studio Code and using the json completion output. I noticed that very often the chunks field would include a bunch of random data and it was because the `Completions::Candidate` struct gets reused if a completion is rejected and the chunks weren't cleared when this happens.