### PR TITLE
Fixed regex crash with GCC 4.8

### DIFF
--- a/src/RClient.cpp
+++ b/src/RClient.cpp
@@ -745,7 +745,7 @@ CommandLineParser::ParseStatus RClient::parse(size_t argc, char **argv)
             break; }
         case SymbolInfo: {
             std::cmatch match;
-            std::regex rx("^(.*):([0-9]+):([0-9]+):?-:?([0-9]+):([0-9]+):?(@[A-Za-z,]+)?");
+            std::regex rx("^(.*):([0-9]+):([0-9]+):?-:?([0-9]+):([0-9]+):?(@[A-Za-z,]+)?", std::regex_constants::basic);
             Path path;
             List<String> kinds;
             uint32_t line = 0, col = 0, line2 = 0, col2 = 0;
@@ -761,7 +761,7 @@ CommandLineParser::ParseStatus RClient::parse(size_t argc, char **argv)
                     return { String::format<1024>("Can't parse range %s", value.constData()), CommandLineParser::Parse_Error };
                 }
             } else {
-                std::regex rx2("^(.*):([0-9]+):([0-9]+):?(@[A-Za-z,]+)?");
+                std::regex rx2("^(.*):([0-9]+):([0-9]+):?(@[A-Za-z,]+)?", std::regex_constants::basic);
                 if (std::regex_match(value.constData(), match, rx2)) {
                     path.assign(value.constData(), match.length(1));
                     line = atoi(value.constData() + match.position(2));


### PR DESCRIPTION
Added argument 'std::regex_constants::basic' to regex constructors.

This fixes runtime crash when rc is called with --symbol-info.

A crash looks like this:
```
terminate called after throwing an instance of 'std::regex_error'
  what():  regex_error
```

This affects versions of the C++ library where the regex module is not
fully implemented. See this SO thread for more details:

http://stackoverflow.com/questions/8060025/is-this-c11-regex-error-me-or-the-compiler

See also the provided stack trace:
```
(gdb) run --symbol-info
Starting program: /usr/bin/rc --symbol-info
Loading gdb's copy of v17 libstdc++ pretty-printers.
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/usr/grte/v4/lib64/libthread_db.so.1".
terminate called after throwing an instance of 'std::regex_error'
  what():  regex_error

Program received signal SIGABRT, Aborted.
0x00007ffff5f7cc37 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
56	../nptl/sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) where
#0  0x00007ffff5f7cc37 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
#1  0x00007ffff5f80028 in __GI_abort () at abort.c:89
#2  0x00007ffff6ec6535 in __gnu_cxx::__verbose_terminate_handler () at ../../../../src/libstdc++-v3/libsupc++/vterminate.cc:95
#3  0x00007ffff6ec46d6 in __cxxabiv1::__terminate (handler=<optimized out>) at ../../../../src/libstdc++-v3/libsupc++/eh_terminate.cc:38
#4  0x00007ffff6ec4703 in std::terminate () at ../../../../src/libstdc++-v3/libsupc++/eh_terminate.cc:48
#5  0x00007ffff6ec4922 in __cxxabiv1::__cxa_throw (obj=0xd0b2a0, tinfo=0x7ffff71518b0 <typeinfo for std::regex_error>, dest=0x7ffff6f174f0 <std::regex_error::~regex_error()>) at ../../../../src/libstdc++-v3/libsupc++/eh_throw.cc:87
#6  0x00007ffff6f16955 in std::__throw_regex_error (__ecode=std::regex_constants::_S_error_brack) at ../../../../../src/libstdc++-v3/src/c++11/functexcept.cc:118
#7  0x0000000000791121 in std::__detail::_Compiler<char const*, std::regex_traits<char> >::_M_bracket_expression (this=0x7fffffff9210) at /usr/include/c++/4.8/bits/regex_compiler.h:974
#8  0x000000000078c15c in std::__detail::_Compiler<char const*, std::regex_traits<char> >::_M_atom (this=0x7fffffff9210) at /usr/include/c++/4.8/bits/regex_compiler.h:960
#9  0x0000000000785b92 in std::__detail::_Compiler<char const*, std::regex_traits<char> >::_M_term (this=0x7fffffff9210) at /usr/include/c++/4.8/bits/regex_compiler.h:795
#10 0x000000000077d4cb in std::__detail::_Compiler<char const*, std::regex_traits<char> >::_M_alternative (this=0x7fffffff9210) at /usr/include/c++/4.8/bits/regex_compiler.h:773
#11 0x0000000000774caf in std::__detail::_Compiler<char const*, std::regex_traits<char> >::_M_disjunction (this=0x7fffffff9210) at /usr/include/c++/4.8/bits/regex_compiler.h:758
#12 0x000000000078c04e in std::__detail::_Compiler<char const*, std::regex_traits<char> >::_M_atom (this=0x7fffffff9210) at /usr/include/c++/4.8/bits/regex_compiler.h:947
#13 0x0000000000785b92 in std::__detail::_Compiler<char const*, std::regex_traits<char> >::_M_term (this=0x7fffffff9210) at /usr/include/c++/4.8/bits/regex_compiler.h:795
#14 0x000000000077d4cb in std::__detail::_Compiler<char const*, std::regex_traits<char> >::_M_alternative (this=0x7fffffff9210) at /usr/include/c++/4.8/bits/regex_compiler.h:773
#15 0x000000000077d515 in std::__detail::_Compiler<char const*, std::regex_traits<char> >::_M_alternative (this=0x7fffffff9210) at /usr/include/c++/4.8/bits/regex_compiler.h:776
#16 0x000000000077d515 in std::__detail::_Compiler<char const*, std::regex_traits<char> >::_M_alternative (this=0x7fffffff9210) at /usr/include/c++/4.8/bits/regex_compiler.h:776
#17 0x000000000077d515 in std::__detail::_Compiler<char const*, std::regex_traits<char> >::_M_alternative (this=0x7fffffff9210) at /usr/include/c++/4.8/bits/regex_compiler.h:776
#18 0x0000000000774caf in std::__detail::_Compiler<char const*, std::regex_traits<char> >::_M_disjunction (this=0x7fffffff9210) at /usr/include/c++/4.8/bits/regex_compiler.h:758
#19 0x000000000076d0b6 in std::__detail::_Compiler<char const*, std::regex_traits<char> >::_Compiler (this=0x7fffffff9210, __b=@0x7fffffff9310: 0x9e41a0 "^(.*):([0-9]+):([0-9]+):?-:?([0-9]+):([0-9]+):?(@[A-Za-z,]+)?", __e=@0x7fffffff9320: 0x9e41dd "", __traits=..., __flags=16)
    at /usr/include/c++/4.8/bits/regex_compiler.h:729
#20 0x0000000000762ada in std::__detail::__compile<char const*, std::regex_traits<char> > (__b=@0x7fffffff9310: 0x9e41a0 "^(.*):([0-9]+):([0-9]+):?-:?([0-9]+):([0-9]+):?(@[A-Za-z,]+)?", __e=@0x7fffffff9320: 0x9e41dd "", __t=..., __f=16)
    at /usr/include/c++/4.8/bits/regex_compiler.h:1105
#21 0x000000000075dfe8 in std::basic_regex<char, std::regex_traits<char> >::basic_regex (this=0x7fffffff9520, __p=0x9e41a0 "^(.*):([0-9]+):([0-9]+):?-:?([0-9]+):([0-9]+):?(@[A-Za-z,]+)?", __f=16) at /usr/include/c++/4.8/bits/regex.h:388
#22 0x00000000007448aa in RClient::__lambda8::operator()(RClient::OptionType, <unknown type in /home/aleloi/rtags/bin/rc, CU 0x431ef, DIE 0xde78f>, size_t &, const List<String> &) const (__closure=0xd087d0, type=RClient::SymbolInfo,
    value=<unknown type in /home/aleloi/rtags/bin/rc, CU 0x431ef, DIE 0xde78f>, idx=@0x7fffffffd8f0: 1, arguments=...) at /home/aleloi/rtags/src/RClient.cpp:744
#23 0x000000000074bde5 in std::_Function_handler<CommandLineParser::ParseStatus(RClient::OptionType, String&&, long unsigned int&, const List<String>&), RClient::parse(size_t, char**)::__lambda8>::_M_invoke(const std::_Any_data &, RClient::OptionType, <unknown type in /home/aleloi/rtags/bin/rc, CU 0x431ef, DIE 0xde78f>, unsigned long &, const List<String> &) (__functor=..., __args#0=RClient::SymbolInfo, __args#1=<unknown type in /home/aleloi/rtags/bin/rc, CU 0x431ef, DIE 0xde78f>, __args#2=@0x7fffffffd8f0: 1, __args#3=...)
    at /usr/include/c++/4.8/functional:2057
#24 0x0000000000769cfd in std::function<CommandLineParser::ParseStatus (RClient::OptionType, String&&, unsigned long&, List<String> const&)>::operator()(RClient::OptionType, String&&, unsigned long&, List<String> const&) const (this=0x7fffffffdbd0, __args#0=RClient::SymbolInfo,
    \\\__args#1=<unknown type in /home/aleloi/rtags/bin/rc, CU 0x431ef, DIE 0xde78f>, __args#2=@0x7fffffffd8f0: 1, __args#3=...) at /usr/include/c++/4.8/functional:2471
#25 0x000000000075ff4f in CommandLineParser::parse<RClient::OptionType>(int, char**, std::initializer_list<CommandLineParser::Option<RClient::OptionType> >, Flags<CommandLineParser::Flag>, std::function<CommandLineParser::ParseStatus (RClient::OptionType, String&&, unsigned long&, List<String> const&)> const&, String const&, std::initializer_list<CommandLineParser::Option<CommandLineParser::ConfigOptionType> >, String*) (argc=2, argv=0x7fffffffdf18, optsList=..., flags=..., handler=..., app=..., configOpts=..., cmdLine=0x7fffffffde08)
    at /home/aleloi/rtags/src/CommandLineParser.h:214
#26 0x00000000007492fc in RClient::parse (this=0x7fffffffdc90, argc=2, argv=0x7fffffffdf18) at /home/aleloi/rtags/src/RClient.cpp:1277
#27 0x0000000000741084 in main (argc=2, argv=0x7fffffffdf18) at /home/aleloi/rtags/src/rc.cpp:22
```