### PR TITLE
Fix preprocessor. -o should not be appended to the compiler command line.

### DIFF
--- a/src/Preprocessor.h
+++ b/src/Preprocessor.h
@@ -31,6 +31,7 @@ public:
 private:
     void onProcessFinished();
     const Source mSource;
+    List<String> mArgs;
     std::shared_ptr<Connection> mConnection;
     std::unique_ptr<Process> mProcess;
 };

--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -1450,6 +1450,7 @@ String Project::toCompileCommands() const
                                                   | Source::IncludeSourceFile
                                                   | Source::IncludeDefines
                                                   | Source::IncludeIncludePaths
+                                                  | Source::IncludeOutputFilename
                                                   | Source::QuoteDefines
                                                   | Source::FilterBlacklist);
     Value ret;

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -54,7 +54,7 @@ Path Source::compiler() const
 
 String Source::toString() const
 {
-    String ret = String::join(toCommandLine(IncludeCompiler|IncludeSourceFile|IncludeIncludePaths|QuoteDefines|IncludeDefines), ' ');
+    String ret = String::join(toCommandLine(IncludeCompiler|IncludeSourceFile|IncludeIncludePaths|QuoteDefines|IncludeDefines|IncludeOutputFilename), ' ');
     if (buildRootId)
         ret << " Build: " << buildRoot();
     if (compileCommandsFileId)
@@ -521,6 +521,7 @@ SourceList Source::parse(const String &cmdLine,
     int32_t sysRootIndex = -1;
     uint32_t buildRootId = 0;
     Path buildRoot;
+    Path outputFilename;
     uint32_t compilerId = 0;
     uint64_t includePathHash = 0;
     bool validCompiler = false;
@@ -680,7 +681,7 @@ SourceList Source::parse(const String &cmdLine,
                         buildRoot.clear();
                     }
                 }
-                arguments << "-o" << p;
+                outputFilename = p;
             } else {
                 arguments.append(arg);
                 if (hasValue(arg)) {
@@ -762,6 +763,7 @@ SourceList Source::parse(const String &cmdLine,
             source.includePaths = includePaths;
             source.arguments = arguments;
             source.sysRootIndex = sysRootIndex;
+            source.outputFilename = outputFilename;
             source.language = input.language;
             assert(source.language != NoLanguage);
             ret.emplace_back(std::move(source));
@@ -994,6 +996,9 @@ List<String> Source::toCommandLine(Flags<CommandLineFlag> f, bool *usedPch) cons
                 }
             }
         }
+    }
+    if (f & IncludeOutputFilename && !outputFilename.isEmpty()) {
+        ret << "-o" << outputFilename;
     }
     if (f & IncludeRTagsConfig) {
         ret << config.value("add-arguments").split(' ');

--- a/src/Source.h
+++ b/src/Source.h
@@ -68,7 +68,8 @@ struct Source
         ExcludeDefaultDefines = 0x200,
         IncludeRTagsConfig = 0x400,
         PCHEnabled = 0x800,
-        Default = IncludeDefines|IncludeIncludePaths|FilterBlacklist|IncludeRTagsConfig
+        IncludeOutputFilename = 0x1000,
+        Default = IncludeDefines|IncludeIncludePaths|FilterBlacklist|IncludeRTagsConfig|IncludeOutputFilename,
     };
 
     struct Define {
@@ -142,6 +143,7 @@ struct Source
     List<String> arguments;
     int32_t sysRootIndex;
     Path directory;
+    Path outputFilename;
 
     bool isValid() const { return fileId; }
     bool isNull() const  { return !fileId; }


### PR DESCRIPTION
`rc --preprocess` should not append the `-o` option to the compiler command line.