### PR TITLE
Add directives to systemd service to make rdm very nice

### DIFF
--- a/README.org
+++ b/README.org
@@ -556,7 +556,10 @@ also be socket acivated.
    [Service]
    Type=simple
    ExecStart=$RDM -v --inactivity-timeout 300 --log-flush
-   #+END_EXAMPLE
+   ExecStartPost=/bin/sh -c "echo +19 > /proc/$MAINPID/autogroup"
+   Nice=19
+   CPUSchedulingPolicy=idle
+   #+END_EXAMPLE
 
  3. Replace =$RDM= with the path to your copy of =rdm=, and add any command
     line parameters you might usually use.


### PR DESCRIPTION
Unfortunately just setting 'nice' isn't enough on modern linux since it only effects processes within the same "autogroup". This tells linux to heavily underweight the whole rdm autogroup. You can read more about autogroups at http://man7.org/linux/man-pages/man7/sched.7.html.

This makes it so rdm (and the rp subprocesses) don't interfere with concurrent compiles.