### PR TITLE
Add smarter completion to rtags (#584).

### DIFF
--- a/src/CompletionThread.h
+++ b/src/CompletionThread.h
@@ -30,6 +30,7 @@
 #include "rct/Thread.h"
 #include "Source.h"
 #include "RTags.h"
+#include "StringTokenizer.h"
 
 class CompletionThread : public Thread
 {
@@ -117,7 +118,7 @@ private:
         Completions *next, *prev;
     };
 
-    void printCompletions(const List<const Completions::Candidate *> &completions, Request *request);
+    void printCompletions(const std::vector<MatchResult *> &results, Request *request);
     static bool compareCompletionCandidates(const Completions::Candidate *l,
                                             const Completions::Candidate *r);
 

--- a/src/StringTokenizer.h
+++ b/src/StringTokenizer.h
@@ -1,0 +1,308 @@
+/* This file is part of RTags (http://rtags.net).
+
+   RTags is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   RTags is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with RTags.  If not, see <http://www.gnu.org/licenses/>. */
+
+#ifndef StringTokenizer_h
+#define StringTokenizer_h
+
+#include "gtest/gtest.h"
+#include <string>
+#include <vector>
+#include <cctype>
+#include <algorithm>
+
+using namespace std;
+
+enum MatchResultType
+{
+  NO_MATCH,
+  WORD_BOUNDARY_MATCH,
+  PREFIX_MATCH_CASE_INSENSITIVE,
+  PREFIX_MATCH_CASE_SENSITIVE,
+  EXACT_MATCH_CASE_INSENSITIVE,
+  EXACT_MATCH_CASE_SENSITIVE
+};
+
+static void lower(string &str)
+{
+  transform(str.begin(), str.end(), str.begin(), ::tolower);
+}
+
+static void upper(string &str)
+{
+  transform(str.begin(), str.end(), str.begin(), ::toupper);
+}
+
+class CompletionCandidate
+{
+  public:
+    CompletionCandidate(string n): name(n), signature(""), kind(""), parent(""),
+	brief_comment(""), annotation(""), priority(-1) {}
+
+    string name;
+    string signature;
+    string kind;
+    string parent;
+    string brief_comment;
+    string annotation;
+    int priority;
+};
+
+class MatchResult
+{
+  public:
+    MatchResult(MatchResultType t, CompletionCandidate *c): type(t), candidate(c) {}
+
+    MatchResultType type;
+    CompletionCandidate *candidate;
+};
+
+class NoMatchResult: public MatchResult
+{
+  public:
+    NoMatchResult(CompletionCandidate *c): MatchResult(NO_MATCH, c) {}
+};
+
+class PrefixResult: public MatchResult
+{
+  public:
+    PrefixResult(MatchResultType t, CompletionCandidate *c, unsigned l): MatchResult(t, c), prefix_length(l) {}
+
+    unsigned prefix_length;
+};
+
+class WordBoundaryMatchResult: public MatchResult
+{
+  public:
+    WordBoundaryMatchResult(CompletionCandidate *c, vector<unsigned> &i): MatchResult(WORD_BOUNDARY_MATCH, c), indices(i) {}
+
+    vector<unsigned> indices;
+};
+
+struct MatchResultComparator
+{
+  bool operator()(MatchResult *a, MatchResult *b)
+  {
+    if (a->type != b->type)
+      return a->type > b->type;
+
+    if (a->type == WORD_BOUNDARY_MATCH)
+    {
+      WordBoundaryMatchResult *wba = static_cast<WordBoundaryMatchResult *> (a);
+      WordBoundaryMatchResult *wbb = static_cast<WordBoundaryMatchResult *> (b);
+
+      for (unsigned i = 0; i < wba->indices.size(); i++)
+	if (wba->indices[i] != wbb->indices[i])
+	  return wba->indices[i] > wbb->indices[i];
+    }
+
+    if (a->candidate->priority != b->candidate->priority)
+      return a->candidate->priority < b->candidate->priority;
+
+    return a < b;
+  }
+};
+
+class StringTokenizer
+{
+  public:
+    inline vector<string> break_parts_of_word(const string &str);
+    inline unsigned common_prefix(const string &str1, const string &str2);
+    inline MatchResult *find_match(CompletionCandidate *candidate, const string &query);
+    inline bool is_boundary_match(const vector<string> &parts,
+	const string &query, vector<unsigned> &indices);
+    inline string find_identifier_prefix(const string &line, unsigned column, unsigned *start);
+    inline vector<MatchResult *> find_and_sort_matches(vector<CompletionCandidate *> &candidates, const string &query);
+
+private:
+  inline bool is_boundary_match(const vector<string> &parts,
+      const string &query,
+      vector<unsigned> &indices,
+      unsigned query_start,
+      unsigned current_index);
+};
+
+vector<string>
+StringTokenizer::break_parts_of_word(const string &str)
+{
+  vector<string> result;
+  string buffer;
+
+  for (string::const_iterator c = str.begin(); c != str.end(); c++)
+  {
+    if (*c == '_')
+    {
+      /* Underscore symbol always break */
+      if (!buffer.empty())
+      {
+	result.push_back(buffer);
+	buffer.clear();
+      }
+    }
+    else if(islower(*c))
+    {
+      if (buffer.length() > 1 && isupper(buffer[buffer.length() - 1]))
+      {
+	/* Break: XML|Do.  */
+	size_t l = buffer.length();
+	result.push_back(buffer.substr(0, l - 1));
+	buffer = buffer.substr (l - 1, 1);
+      }
+      else if(!buffer.empty() && isdigit(buffer[buffer.length() - 1]))
+      {
+	/* Break: 0|D.  */
+	result.push_back(buffer);
+	buffer.clear();
+      }
+
+      buffer += *c;
+    }
+    else if (isupper(*c))
+    {
+      /* Break: a|D or 0|D.  */
+      if (!buffer.empty () && !isupper(buffer[buffer.length() - 1]))
+      {
+	result.push_back(buffer);
+	buffer.clear();
+      }
+
+      buffer += *c;
+    }
+    else if(isdigit(*c))
+    {
+      /* Break: a|0 or A|0.  */
+      if (!buffer.empty() && !isdigit(buffer[buffer.length() - 1]))
+      {
+	result.push_back(buffer);
+	buffer.clear();
+      }
+
+      buffer += *c;
+    }
+  }
+
+  if (!buffer.empty())
+    result.push_back(buffer);
+
+  /* Lower all parts of result.  */
+  for(unsigned i = 0; i < result.size(); i++)
+    lower(result[i]);
+
+  return result;
+}
+
+unsigned StringTokenizer::common_prefix(const string &str1, const string &str2)
+{
+  unsigned l = std::min(str1.length(), str2.length());
+
+  for (unsigned i = 0; i < l; i++)
+    if (str1[i] != str2[i])
+      return i;
+
+  return l;
+}
+
+MatchResult *
+StringTokenizer::find_match(CompletionCandidate *candidate, const string &query)
+{
+  string c = candidate->name;
+
+  if (query.length() > c.length())
+    return new NoMatchResult(candidate);
+
+  string c_lower = c;
+  lower(c_lower);
+  string query_lower = query;
+  lower(query_lower);
+
+  bool are_equal = c.length() == query.length();
+  if(equal(query.begin(), query.end(), c.begin()))
+    return new PrefixResult(are_equal ? EXACT_MATCH_CASE_SENSITIVE : PREFIX_MATCH_CASE_SENSITIVE,
+	candidate, query.length());
+
+  if(equal(query_lower.begin(), query_lower.end(), c_lower.begin()))
+    return new PrefixResult(are_equal ? EXACT_MATCH_CASE_INSENSITIVE : PREFIX_MATCH_CASE_INSENSITIVE,
+	candidate, query.length());
+
+  vector<string> words = StringTokenizer().break_parts_of_word(c);
+  vector<unsigned> indices;
+  bool r = is_boundary_match(words, query_lower, indices);
+  if (r)
+    return new WordBoundaryMatchResult(candidate, indices);
+
+  return new NoMatchResult(candidate);
+}
+
+static bool isnotalnum(char c)
+{
+  return !isalnum(c);
+}
+
+bool StringTokenizer::is_boundary_match(const vector<string> &parts,
+    const string &query,
+    vector<unsigned> &indices)
+{
+  /* Strip non-alphanum characters from candidate.  */
+  string stripped = query;
+  stripped.erase(remove_if(stripped.begin(), stripped.end(), isnotalnum), stripped.end());
+
+  indices.resize(parts.size());
+  return is_boundary_match(parts, stripped, indices, 0, 0);
+}
+
+bool StringTokenizer::is_boundary_match(const vector<string> &parts,
+    const string &query,
+    vector<unsigned> &indices,
+    unsigned query_start,
+    unsigned current_index)
+{
+  if (query_start == query.length())
+    return true;
+  else if(current_index == parts.size())
+    return false;
+
+  string to_find = query.substr(query_start, query.length() - query_start);
+  unsigned longest_prefix = common_prefix(parts[current_index], to_find);
+
+  for (int i = longest_prefix; i >= 0; i--)
+  {
+    indices[current_index] = i;
+    bool r = is_boundary_match(parts, query, indices, query_start + i, current_index + 1);
+    if (r)
+      return r;
+  }
+
+  return false;
+}
+
+vector<MatchResult *>
+StringTokenizer::find_and_sort_matches(vector<CompletionCandidate *> &candidates, const string &query)
+{
+  vector<MatchResult *> results;
+
+  for (vector<CompletionCandidate *>::const_iterator c = candidates.begin(); c != candidates.end(); c++)
+  {
+    MatchResult *r = find_match(*c, query);
+    if (r->type != NO_MATCH)
+      results.push_back(r);
+    else
+      delete r;
+  }
+
+  sort(results.begin(), results.end(), MatchResultComparator());
+
+  return results;
+}
+
+#endif

--- a/src/StringTokenizerTests.cpp
+++ b/src/StringTokenizerTests.cpp
@@ -1,0 +1,294 @@
+#include "StringTokenizer.h"
+
+TEST (StringTokenizerTest, BreakIdentifierWithUnderscore)
+{
+  vector<string> result = StringTokenizer().break_parts_of_word("my_shiny_identifier");
+
+  ASSERT_EQ (3, result.size());
+  ASSERT_EQ ("my", result[0]);
+  ASSERT_EQ ("shiny", result[1]);
+  ASSERT_EQ ("identifier", result[2]);
+}
+
+TEST (StringTokenizerTest, BreakIdentifierWithCamelCase)
+{
+  vector<string> result = StringTokenizer().break_parts_of_word("MyShinyIdentifier");
+
+  ASSERT_EQ (3, result.size());
+  ASSERT_EQ ("my", result[0]);
+  ASSERT_EQ ("shiny", result[1]);
+  ASSERT_EQ ("identifier", result[2]);
+}
+
+TEST (StringTokenizerTest, BreakIdentifierWithUpperLetters)
+{
+  vector<string> result = StringTokenizer().break_parts_of_word("MyShinyXYZIdentifier");
+
+  ASSERT_EQ (4, result.size());
+  ASSERT_EQ ("my", result[0]);
+  ASSERT_EQ ("shiny", result[1]);
+  ASSERT_EQ ("xyz", result[2]);
+  ASSERT_EQ ("identifier", result[3]);
+}
+
+TEST (StringTokenizerTest, BreakIdentifierWithDigits)
+{
+  vector<string> result = StringTokenizer().break_parts_of_word("foo12345bar");
+
+  ASSERT_EQ (3, result.size());
+  ASSERT_EQ ("foo", result[0]);
+  ASSERT_EQ ("12345", result[1]);
+  ASSERT_EQ ("bar", result[2]);
+}
+
+TEST (StringTokenizerTest, BreakIdentifierWithDigitsAtBeginning)
+{
+  vector<string> result = StringTokenizer().break_parts_of_word("12345FooBar");
+
+  ASSERT_EQ (3, result.size());
+  ASSERT_EQ ("12345", result[0]);
+  ASSERT_EQ ("foo", result[1]);
+  ASSERT_EQ ("bar", result[2]);
+}
+
+TEST (StringTokenizerTest, BreakVeryComplexIdentifier)
+{
+  vector<string> result = StringTokenizer().break_parts_of_word("XYZ12345XMLDocument");
+
+  ASSERT_EQ (4, result.size());
+  ASSERT_EQ ("xyz", result[0]);
+  ASSERT_EQ ("12345", result[1]);
+  ASSERT_EQ ("xml", result[2]);
+  ASSERT_EQ ("document", result[3]);
+}
+
+TEST (StringTokenizerTest, BreakVeryComplexIdentifierWithUnderscore)
+{
+  vector<string> result = StringTokenizer().break_parts_of_word("XYZ12345XM_LDocument");
+
+  ASSERT_EQ (5, result.size());
+  ASSERT_EQ ("xyz", result[0]);
+  ASSERT_EQ ("12345", result[1]);
+  ASSERT_EQ ("xm", result[2]);
+  ASSERT_EQ ("l", result[3]);
+  ASSERT_EQ ("document", result[4]);
+}
+
+static bool test_word_boundary_match(const string &name, const string &candidate,
+    vector<unsigned> &match_result)
+{
+  vector<string> words = StringTokenizer().break_parts_of_word(name);
+  return StringTokenizer().is_boundary_match(words, candidate, match_result);
+}
+
+TEST (StringTokenizerTest, MatchSimpleSearchPattern)
+{
+  vector<unsigned> match_result;
+  bool r = test_word_boundary_match ("foo_bar_text", "fb", match_result);
+  ASSERT_TRUE(r);
+  ASSERT_EQ(1, match_result[0]);
+  ASSERT_EQ(1, match_result[1]);
+}
+
+TEST (StringTokenizerTest, CommonPrefix)
+{
+  ASSERT_EQ (3, StringTokenizer().common_prefix("sparta", "spa"));
+  ASSERT_EQ (3, StringTokenizer().common_prefix("spa", "sparta"));
+  ASSERT_EQ (0, StringTokenizer().common_prefix("", ""));
+  ASSERT_EQ (0, StringTokenizer().common_prefix("xyz", "abc"));
+}
+
+TEST (StringTokenizerTest, MatchSimpleSearchPattern2)
+{
+  vector<unsigned> match_result;
+  bool r = test_word_boundary_match ("foo_bar_text", "fbarte", match_result);
+  ASSERT_TRUE(r);
+  ASSERT_EQ(1, match_result[0]);
+  ASSERT_EQ(3, match_result[1]);
+  ASSERT_EQ(2, match_result[2]);
+}
+
+TEST (StringTokenizerTest, MatchSimpleSearchPatternSkipChunks)
+{
+  vector<unsigned> match_result;
+  bool r = test_word_boundary_match ("foo_bar_text_sparta", "ftexts", match_result);
+  ASSERT_TRUE(r);
+  ASSERT_EQ(1, match_result[0]);
+  ASSERT_EQ(0, match_result[1]);
+  ASSERT_EQ(4, match_result[2]);
+  ASSERT_EQ(1, match_result[3]);
+}
+
+TEST (StringTokenizerTest, MatchSimpleSearchPatternInvalid)
+{
+  vector<unsigned> match_result;
+  bool r = test_word_boundary_match ("foo_bar_text", "fbx", match_result);
+  ASSERT_FALSE(r);
+}
+
+TEST (StringTokenizerTest, MatchSimpleSearchPatternWithInvalidCandidateChars)
+{
+  vector<unsigned> match_result;
+  bool r = test_word_boundary_match ("foo_bar_text", "f_^@ba", match_result);
+  ASSERT_TRUE(r);
+  ASSERT_EQ(1, match_result[0]);
+  ASSERT_EQ(2, match_result[1]);
+  ASSERT_EQ(0, match_result[2]);
+}
+
+TEST (StringTokenizerTest, MatchSimpleSearchPatternComplex)
+{
+  vector<unsigned> match_result;
+  bool r = test_word_boundary_match ("ob_obsah_s", "obsas", match_result);
+  ASSERT_TRUE(r);
+  ASSERT_EQ(0, match_result[0]);
+  ASSERT_EQ(4, match_result[1]);
+  ASSERT_EQ(1, match_result[2]);
+}
+
+TEST (StringTokenizerTest, MatchSimpleSearchPatternComplex2)
+{
+  vector<unsigned> match_result;
+  bool r = test_word_boundary_match ("spa_pax_paxo_paxon", "spaxon", match_result);
+  ASSERT_TRUE(r);
+  ASSERT_EQ(1, match_result[0]);
+  ASSERT_EQ(0, match_result[1]);
+  ASSERT_EQ(0, match_result[2]);
+  ASSERT_EQ(5, match_result[3]);
+}
+
+TEST (StringTokenizerTest, FindMatchInvalid)
+{
+  MatchResult *r = StringTokenizer().find_match(new CompletionCandidate("foo_bar"), "xyz");
+  ASSERT_EQ (NO_MATCH, r->type);
+  delete r;
+}
+
+TEST (StringTokenizerTest, FindMatchInvalidSmaller)
+{
+  MatchResult *r = StringTokenizer().find_match(new CompletionCandidate("foo_bar"), "foo_bar_");
+  ASSERT_EQ (NO_MATCH, r->type);
+  delete r;
+}
+
+TEST (StringTokenizerTest, FindMatchExactCaseSensitive)
+{
+  MatchResult *r = StringTokenizer().find_match(new CompletionCandidate("FooBar"), "FooBar");
+  ASSERT_EQ (EXACT_MATCH_CASE_SENSITIVE, r->type);
+  delete r;
+}
+
+TEST (StringTokenizerTest, FindMatchExactCaseInsensitive)
+{
+  MatchResult *r = StringTokenizer().find_match(new CompletionCandidate("FooBar"), "Foobar");
+  ASSERT_EQ (EXACT_MATCH_CASE_INSENSITIVE, r->type);
+  delete r;
+}
+
+TEST (StringTokenizerTest, FindMatchPrefixCaseSensitive)
+{
+  MatchResult *r = StringTokenizer().find_match(new CompletionCandidate("FooBarBaz"), "FooBar");
+  ASSERT_EQ (PREFIX_MATCH_CASE_SENSITIVE, r->type);
+  delete r;
+}
+
+TEST (StringTokenizerTest, FindMatchPrefixCaseInsensitive)
+{
+  MatchResult *r = StringTokenizer().find_match(new CompletionCandidate("FooBarBaz"), "Foobar");
+  ASSERT_EQ (PREFIX_MATCH_CASE_INSENSITIVE, r->type);
+  delete r;
+}
+
+TEST (StringTokenizerTest, FindMatchWordBoundary)
+{
+  MatchResult *r = StringTokenizer().find_match(new CompletionCandidate("FooBarBaz"), "fbb");
+  ASSERT_EQ (WORD_BOUNDARY_MATCH, r->type);
+
+  WordBoundaryMatchResult *wbm = static_cast<WordBoundaryMatchResult *> (r);
+  ASSERT_EQ (1, wbm->indices[0]);
+  ASSERT_EQ (1, wbm->indices[1]);
+  ASSERT_EQ (1, wbm->indices[2]);
+  delete wbm;
+}
+
+static vector<MatchResult *> test_find_and_sort_matches(vector<string> &candidate_names, const string &query)
+{
+  vector<CompletionCandidate *> candidates;
+  for(unsigned i = 0; i < candidate_names.size(); i++)
+    candidates.push_back(new CompletionCandidate(candidate_names[i]));
+
+  return StringTokenizer().find_and_sort_matches(candidates, query);
+}
+
+TEST (StringTokenizerTest, FindAndSortResultsSimple)
+{
+  vector<string> names = {"foo", "bar", "baz"};
+  vector<MatchResult *> results = test_find_and_sort_matches(names, "fo");
+
+  ASSERT_EQ(1, results.size());
+  ASSERT_EQ(PREFIX_MATCH_CASE_SENSITIVE, results[0]->type);
+  ASSERT_EQ("foo", results[0]->candidate->name);
+}
+
+TEST (StringTokenizerTest, FindAndSortResultsSimpleMultiple)
+{
+  vector<string> names = {"foo", "fredy", "baz", "f"};
+  vector<MatchResult *> results = test_find_and_sort_matches(names, "f");
+
+  ASSERT_EQ(3, results.size());
+  ASSERT_EQ("f", results[0]->candidate->name);
+  ASSERT_EQ(EXACT_MATCH_CASE_SENSITIVE, results[0]->type);
+  ASSERT_EQ("foo", results[1]->candidate->name);
+  ASSERT_EQ(PREFIX_MATCH_CASE_SENSITIVE, results[1]->type);
+  ASSERT_EQ("fredy", results[2]->candidate->name);
+  ASSERT_EQ(PREFIX_MATCH_CASE_SENSITIVE, results[2]->type);
+}
+
+TEST (StringTokenizerTest, FindAndSortResultsCaseSensitivity)
+{
+  vector<string> names = {"Fr", "Fredy", "Baz", "franko", "fr"};
+  vector<MatchResult *> results = test_find_and_sort_matches(names, "Fr");
+
+  ASSERT_EQ(4, results.size());
+  ASSERT_EQ("Fr", results[0]->candidate->name);
+  ASSERT_EQ(EXACT_MATCH_CASE_SENSITIVE, results[0]->type);
+  ASSERT_EQ("fr", results[1]->candidate->name);
+  ASSERT_EQ(EXACT_MATCH_CASE_INSENSITIVE, results[1]->type);
+  ASSERT_EQ("Fredy", results[2]->candidate->name);
+  ASSERT_EQ(PREFIX_MATCH_CASE_SENSITIVE, results[2]->type);
+  ASSERT_EQ("franko", results[3]->candidate->name);
+  ASSERT_EQ(PREFIX_MATCH_CASE_INSENSITIVE, results[3]->type);
+}
+
+TEST (StringTokenizerTest, FindAndSortResultsCaseMixture)
+{
+  vector<string> names = {"fbar", "f_call_bar", "from_bar_and_read", "gnome", "", "ffbar"};
+  vector<MatchResult *> results = test_find_and_sort_matches(names, "fbar");
+
+  ASSERT_EQ(3, results.size());
+  ASSERT_EQ(EXACT_MATCH_CASE_SENSITIVE, results[0]->type);
+  ASSERT_EQ("fbar", results[0]->candidate->name);
+  ASSERT_EQ(WORD_BOUNDARY_MATCH, results[1]->type);
+  ASSERT_EQ("from_bar_and_read", results[1]->candidate->name);
+  ASSERT_EQ(WORD_BOUNDARY_MATCH, results[2]->type);
+  ASSERT_EQ("f_call_bar", results[2]->candidate->name);
+}
+
+TEST (StringTokenizerTest, FindAndSortResultsLongerPrefixAtBeginning)
+{
+  vector<string> names = {"get_long_value_with_very_nice", "gloooveshark", "get_small_and_long", "gl_o"};
+  vector<MatchResult *> results = test_find_and_sort_matches(names, "glo");
+
+  ASSERT_EQ(4, results.size());
+  ASSERT_EQ("gloooveshark", results[0]->candidate->name);
+  ASSERT_EQ("gl_o", results[1]->candidate->name);
+  ASSERT_EQ("get_long_value_with_very_nice", results[2]->candidate->name);
+  ASSERT_EQ("get_small_and_long", results[3]->candidate->name);
+}
+
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS ();
+}


### PR DESCRIPTION
Ok, after quite some time I finished the plan to introduce more sophisticated code completion (which is described in the #584). To be honest I haven't fixed integration of unit tests and coding style is probably not precise.

I'm planning to do a follow up work and send the patch as soon as possible. For the coding style I would recommend to use clang-format (I can prepare a configuration file), so that one can use it to format code in more automated way.

I'm looking forward to feedback for the patch.