### PR TITLE
helm-rtags-candidates: Add new candidates to the end of ret

### DIFF
--- a/src/helm-rtags.el
+++ b/src/helm-rtags.el
@@ -71,7 +71,7 @@ Each element of the alist is a cons-cell of the form (DESCRIPTION . FUNCTION)."
             (forward-line 1))
           (let (done)
             (while (not done)
-              (push (cons (buffer-substring-no-properties (point-at-bol) (point-at-eol)) (point-at-bol)) ret)
+              (setq ret (append ret (list (cons (buffer-substring-no-properties (point-at-bol) (point-at-eol)) (point-at-bol)))))
               (if (= (point-at-eol) (point-max))
                   (setq done t)
                 (forward-line 1)))))))


### PR DESCRIPTION
This way, candidates are presented in the same order as they appear in the rtags
buffer and the default backend to the user.