### PR TITLE
remove typo that break the layout.

### DIFF
--- a/README.org
+++ b/README.org
@@ -560,10 +560,10 @@ also be socket acivated.
    [Service]
    Type=simple
    ExecStart=$RDM -v --inactivity-timeout 300 --log-flush
-   ExecStartPost=/bin/sh -c "echo +19 > /proc/$MAINPID/autogroup"
+   ExecStartPost=/bin/sh -c "echo +19 > /proc/$MAINPID/autogroup"
    Nice=19
    CPUSchedulingPolicy=idle
-   #+END_EXAMPLE
+   #+END_EXAMPLE
 
  3. Replace =$RDM= with the path to your copy of =rdm=, and add any command
     line parameters you might usually use.


### PR DESCRIPTION
The text is mixed with code in section "Integration with systemd (GNU Linux)".

