### PR TITLE
Add [[gnu::fallthrough]] to cases which fall through.

### DIFF
--- a/src/ClangIndexer.cpp
+++ b/src/ClangIndexer.cpp
@@ -473,6 +473,7 @@ String ClangIndexer::addNamePermutations(const CXCursor &cursor, Location locati
                 // namespaces can include all namespaces in their symbolname
                 if (originalKind == CXCursor_Namespace)
                     break;
+                [[gnu::fallthrough]];
             default:
                 cutoff = pos;
                 break;

--- a/src/IncludeFileJob.cpp
+++ b/src/IncludeFileJob.cpp
@@ -76,6 +76,7 @@ int IncludeFileJob::execute()
                 case CXCursor_TypedefDecl:
                     if (!sym.isDefinition())
                         break;
+                    [[gnu::fallthrough]];
                 case CXCursor_FunctionDecl:
                 case CXCursor_FunctionTemplate: {
                     List<String> alternatives;

--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -1559,6 +1559,7 @@ Set<Symbol> Project::findTargets(const Symbol &symbol)
         case CXCursor_StructDecl:
             if (symbol.isDefinition() && !(symbol.flags & Symbol::TemplateSpecialization))
                 return ret;
+            [[gnu::fallthrough]];
         case CXCursor_FunctionDecl:
         case CXCursor_CXXMethod:
         case CXCursor_Destructor:


### PR DESCRIPTION
Fix warnings seen by GCC 7. Please take a look that in all these cases fall through is desired.