### PR TITLE
allow relative source paths in compile_commands.json

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -502,7 +502,16 @@ bool Server::loadCompileCommands(IndexParseData &data, const Path &compileComman
         CXCompileCommand cmd = clang_CompileCommands_getCommand(cmds, i);
         String args;
         CXString str = clang_CompileCommand_getDirectory(cmd);
-        const Path compileDir = clang_getCString(str);
+        Path compileDir = clang_getCString(str);
+        if (!compileDir.isAbsolute() || !compileDir.exists()) {
+            bool resolveOk = false;
+            debug() << "compileDir doesn't exist: " << compileDir;
+            Path resolvedCompileDir = compileDir.resolved(Path::MakeAbsolute, data.project, &resolveOk);
+            if (resolveOk) {
+                compileDir = resolvedCompileDir;
+                debug() << "    resolved to: " << compileDir;
+            }
+        }
         clang_disposeString(str);
         const unsigned int num = clang_CompileCommand_getNumArgs(cmd);
         for (unsigned int j = 0; j < num; ++j) {


### PR DESCRIPTION
Allow relative source paths in compile_commands.json by using rc's --project-root to resolve the path

I'm using bazel to generate the compile_commands.json file. As bazel builds follow the concept of encapsulation in a sandbox for reproducibility, there is no built-in way to get access to absolute paths of the sources/headers. Therefore I adapted rtags to be able scan for sources with a relative path (related to project root). To resolve the path to be absolute, I used rc's argument --project-root (not sure if that was the right way to do it).

To generate the compilation database with bazel there is the project https://github.com/grailbio/bazel-compilation-database which I needed also to modify a bit.

Any feedback is welcome.
BTW: I really appreciate your work on rtags, thanks!