### PR TITLE
Fix performance issues found by clang-tidy

### DIFF
--- a/src/CompilerManager.cpp
+++ b/src/CompilerManager.cpp
@@ -49,7 +49,7 @@ List<Path> compilers()
     return sCompilers.keys();
 }
 
-void applyToSource(Source &source, Flags<CompilerManager::Flag> flags)
+void applyToSource(Source &source, const Flags<CompilerManager::Flag>& flags)
 {
     std::lock_guard<std::mutex> lock(sMutex);
     Path cpath = source.compiler();
@@ -142,9 +142,9 @@ void applyToSource(Source &source, Flags<CompilerManager::Flag> flags)
                     // What's left in copy are the builtin paths
                     compiler.builtinPaths = copy;
                     // Set the includePaths exclusive of stdinc/builtin
-                    for (auto inc : compiler.stdincxxPaths)
+                    for (auto& inc : compiler.stdincxxPaths)
                         compiler.includePaths.remove(inc);
-                    for (auto inc : compiler.builtinPaths)
+                    for (auto& inc : compiler.builtinPaths)
                         compiler.includePaths.remove(inc);
                     break; // we're done
                 } else {

--- a/src/CompilerManager.h
+++ b/src/CompilerManager.h
@@ -32,7 +32,7 @@ enum Flag {
     IncludeIncludePaths = 0x2
 };
 RCT_FLAGS(Flag);
-void applyToSource(Source &source, Flags<Flag> flags);
+void applyToSource(Source &source, const Flags<Flag>& flags);
 }
 
 #endif

--- a/src/CompletionThread.cpp
+++ b/src/CompletionThread.cpp
@@ -101,7 +101,7 @@ void CompletionThread::run()
 }
 
 void CompletionThread::completeAt(Source &&source, Location location,
-                                  Flags<Flag> flags, String &&unsaved,
+                                  const Flags<Flag>& flags, String &&unsaved,
                                   const String &prefix,
                                   const std::shared_ptr<Connection> &conn)
 {

--- a/src/CompletionThread.h
+++ b/src/CompletionThread.h
@@ -49,7 +49,7 @@ public:
         NoWait = 0x20
     };
     bool isCached(uint32_t fileId, const std::shared_ptr<Project> &project) const;
-    void completeAt(Source &&source, Location location, Flags<Flag> flags,
+    void completeAt(Source &&source, Location location, const Flags<Flag>& flags,
                     String &&unsaved, const String &prefix,
                     const std::shared_ptr<Connection> &conn);
     void prepare(Source &&source, String &&unsaved);

--- a/src/FindFileJob.cpp
+++ b/src/FindFileJob.cpp
@@ -21,7 +21,7 @@
 #include "RTags.h"
 #include "Server.h"
 
-static Flags<QueryJob::JobFlag> flags(Flags<QueryMessage::Flag> queryFlags)
+static Flags<QueryJob::JobFlag> flags(const Flags<QueryMessage::Flag>& queryFlags)
 {
     Flags<QueryJob::JobFlag> flags = QueryJob::QuietJob;
     if (queryFlags & QueryMessage::Elisp)

--- a/src/FindSymbolsJob.cpp
+++ b/src/FindSymbolsJob.cpp
@@ -21,7 +21,7 @@
 #include "RTags.h"
 #include "Server.h"
 
-static inline Flags<QueryJob::JobFlag> jobFlags(Flags<QueryMessage::Flag> queryFlags)
+static inline Flags<QueryJob::JobFlag> jobFlags(const Flags<QueryMessage::Flag>& queryFlags)
 {
     return (queryFlags & QueryMessage::Elisp
             ? QueryJob::QuoteOutput|QueryJob::QuietJob

--- a/src/IndexerJob.cpp
+++ b/src/IndexerJob.cpp
@@ -25,7 +25,7 @@
 
 uint64_t IndexerJob::sNextId = 1;
 IndexerJob::IndexerJob(const SourceList &s,
-                       Flags<Flag> f,
+                       const Flags<Flag>& f,
                        const std::shared_ptr<Project> &p,
                        const UnsavedFiles &u)
     : id(0), flags(f),
@@ -198,7 +198,7 @@ String IndexerJob::encode() const
     return ret;
 }
 
-String IndexerJob::dumpFlags(Flags<Flag> flags)
+String IndexerJob::dumpFlags(const Flags<Flag>& flags)
 {
     List<String> ret;
     if (flags & Dirty) {

--- a/src/IndexerJob.h
+++ b/src/IndexerJob.h
@@ -38,10 +38,10 @@ public:
         Type_Mask = Dirty|Compile|Reindex
     };
 
-    static String dumpFlags(Flags<Flag> flags);
+    static String dumpFlags(const Flags<Flag>& flags);
 
     IndexerJob(const SourceList &sources,
-               Flags<Flag> flags,
+               const Flags<Flag>& flags,
                const std::shared_ptr<Project> &project,
                const UnsavedFiles &unsavedFiles = UnsavedFiles());
     ~IndexerJob();

--- a/src/Location.cpp
+++ b/src/Location.cpp
@@ -38,7 +38,7 @@ const uint64_t Location::FILEID_MASK = createMask(0, FileBits);
 const uint64_t Location::LINE_MASK = createMask(FileBits, LineBits);
 const uint64_t Location::COLUMN_MASK = createMask(FileBits + LineBits, ColumnBits);
 
-String Location::toString(Flags<ToStringFlag> flags, Hash<Path, String> *contextCache) const
+String Location::toString(const Flags<ToStringFlag>& flags, Hash<Path, String> *contextCache) const
 {
     if (isNull())
         return String();
@@ -73,7 +73,7 @@ String Location::toString(Flags<ToStringFlag> flags, Hash<Path, String> *context
     return ret;
 }
 
-String Location::context(Flags<ToStringFlag> flags, Hash<Path, String> *cache) const
+String Location::context(const Flags<ToStringFlag>& flags, Hash<Path, String> *cache) const
 {
     String copy;
     String *code = 0;

--- a/src/Location.h
+++ b/src/Location.h
@@ -169,8 +169,8 @@ public:
         ConvertToRelative = 0x8
     };
 
-    String toString(Flags<ToStringFlag> flags = NoFlag, Hash<Path, String> *contextCache = 0) const;
-    String context(Flags<ToStringFlag> flags, Hash<Path, String> *cache = 0) const;
+    String toString(const Flags<ToStringFlag>& flags = NoFlag, Hash<Path, String> *contextCache = 0) const;
+    String context(const Flags<ToStringFlag>& flags, Hash<Path, String> *cache = 0) const;
 
     inline String debug() const;
 

--- a/src/Project.h
+++ b/src/Project.h
@@ -135,7 +135,7 @@ public:
     bool dependsOn(uint32_t source, uint32_t header) const;
     String dumpDependencies(uint32_t fileId,
                             const List<String> &args = List<String>(),
-                            Flags<QueryMessage::Flag> flags = Flags<QueryMessage::Flag>()) const;
+                            const Flags<QueryMessage::Flag>& flags = Flags<QueryMessage::Flag>()) const;
     const Hash<uint32_t, DependencyNode*> &dependencies() const { return mDependencies; }
     DependencyNode *dependencyNode(uint32_t fileId) const { return mDependencies.value(fileId); }
 
@@ -148,7 +148,7 @@ public:
     };
     void findSymbols(const String &symbolName,
                      const std::function<void(SymbolMatchType, const String &, const Set<Location> &)> &func,
-                     Flags<QueryMessage::Flag> queryFlags,
+                     const Flags<QueryMessage::Flag>& queryFlags,
                      uint32_t fileFilter = 0);
 
     static bool matchSymbolName(const String &pattern, const String &symbolName, String::CaseSensitivity cs)
@@ -176,7 +176,7 @@ public:
     Path sourceFilePath(uint32_t fileId, const char *path = "") const;
 
     List<RTags::SortedSymbol> sort(const Set<Symbol> &symbols,
-                                   Flags<QueryMessage::Flag> flags = Flags<QueryMessage::Flag>());
+                                   const Flags<QueryMessage::Flag>& flags = Flags<QueryMessage::Flag>());
 
     const Files &files() const { return mFiles; }
     Files &files() { return mFiles; }
@@ -215,7 +215,7 @@ public:
 
     void watch(const Path &dir, WatchMode mode);
     void unwatch(const Path &dir, WatchMode mode);
-    void clearWatch(Flags<WatchMode> mode);
+    void clearWatch(const Flags<WatchMode>& mode);
     Hash<Path, Flags<WatchMode> > watchedPaths() const { return mWatchedPaths; }
 
     bool isIndexing() const { return !mActiveJobs.isEmpty(); }
@@ -242,12 +242,12 @@ public:
     bool save();
     void prepare(uint32_t fileId);
     String estimateMemory() const;
-    String diagnosticsToString(Flags<QueryMessage::Flag> flags, uint32_t fileId);
+    String diagnosticsToString(const Flags<QueryMessage::Flag>& flags, uint32_t fileId);
     void diagnose(uint32_t fileId);
     void diagnoseAll();
     uint32_t fileMapOptions() const;
     void fixPCH(Source &source);
-    void includeCompletions(Flags<QueryMessage::Flag> flags, const std::shared_ptr<Connection> &conn, Source &&source) const;
+    void includeCompletions(const Flags<QueryMessage::Flag>& flags, const std::shared_ptr<Connection> &conn, Source &&source) const;
     size_t bytesWritten() const { return mBytesWritten; }
     void destroy() { mSaveDirty = false; }
     enum VisitResult {
@@ -255,20 +255,20 @@ public:
         Continue,
         Remove // not allowed for const calls
     };
-    static void forEachSources(const IndexParseData &data, std::function<VisitResult(const Sources &sources)> cb);
-    static void forEachSources(IndexParseData &data, std::function<VisitResult(Sources &sources)> cb);
+    static void forEachSources(const IndexParseData &data, const std::function<VisitResult(const Sources &sources)>& cb);
+    static void forEachSources(IndexParseData &data, const std::function<VisitResult(Sources &sources)>& cb);
     void forEachSources(std::function<VisitResult(const Sources &sources)> cb) const { forEachSources(mIndexParseData, cb); }
     void forEachSources(std::function<VisitResult(Sources &sources)> cb) { forEachSources(mIndexParseData, cb); }
 
     static void forEachSourceList(const IndexParseData &data, std::function<VisitResult(const SourceList &sources)> cb);
     static void forEachSourceList(IndexParseData &data, std::function<VisitResult(SourceList &sources)> cb);
-    static void forEachSourceList(Sources &sources, std::function<VisitResult(SourceList &source)> cb);
-    static void forEachSourceList(const Sources &sources, std::function<VisitResult(const SourceList &source)> cb);
+    static void forEachSourceList(Sources &sources, const std::function<VisitResult(SourceList &source)>& cb);
+    static void forEachSourceList(const Sources &sources, const std::function<VisitResult(const SourceList &source)>& cb);
     void forEachSourceList(std::function<VisitResult(const SourceList &sources)> cb) const { forEachSourceList(mIndexParseData, cb); }
     void forEachSourceList(std::function<VisitResult(SourceList &sources)> cb) { forEachSourceList(mIndexParseData, cb); }
 
-    static void forEachSource(Sources &sources, std::function<VisitResult(Source &source)> cb);
-    static void forEachSource(const Sources &sources, std::function<VisitResult(const Source &source)> cb);
+    static void forEachSource(Sources &sources, const std::function<VisitResult(Source &source)>& cb);
+    static void forEachSource(const Sources &sources, const std::function<VisitResult(const Source &source)>& cb);
     static void forEachSource(IndexParseData &data, std::function<VisitResult(Source &source)> cb);
     static void forEachSource(const IndexParseData &data, std::function<VisitResult(const Source &source)> cb);
     void forEachSource(std::function<VisitResult(const Source &source)> cb) const { forEachSource(mIndexParseData, cb); }

--- a/src/QueryJob.cpp
+++ b/src/QueryJob.cpp
@@ -26,7 +26,7 @@
 
 QueryJob::QueryJob(const std::shared_ptr<QueryMessage> &query,
                    const std::shared_ptr<Project> &proj,
-                   Flags<JobFlag> jobFlags)
+                   const Flags<JobFlag>& jobFlags)
     : mAborted(false), mLinesWritten(0), mQueryMessage(query), mJobFlags(jobFlags), mProject(proj), mFileFilter(0)
 {
     if (mProject)
@@ -62,7 +62,7 @@ QueryJob::~QueryJob()
         mProject->endScope();
 }
 
-bool QueryJob::write(const String &out, Flags<WriteFlag> flags)
+bool QueryJob::write(const String &out, const Flags<WriteFlag>& flags)
 {
     if ((mJobFlags & WriteUnfiltered) || (flags & Unfiltered) || filter(out)) {
         if ((mJobFlags & QuoteOutput) && !(flags & DontQuote)) {
@@ -94,7 +94,7 @@ bool QueryJob::write(const String &out, Flags<WriteFlag> flags)
     return true;
 }
 
-bool QueryJob::writeRaw(const String &out, Flags<WriteFlag> flags)
+bool QueryJob::writeRaw(const String &out, const Flags<WriteFlag>& flags)
 {
     assert(mConnection);
     if (!(flags & IgnoreMax) && mQueryMessage) {
@@ -122,7 +122,7 @@ bool QueryJob::writeRaw(const String &out, Flags<WriteFlag> flags)
 
 bool QueryJob::locationToString(Location location,
                                 const std::function<void(LocationPiece, const String &)> &cb,
-                                Flags<WriteFlag> writeFlags)
+                                const Flags<WriteFlag>& writeFlags)
 {
     if (location.isNull())
         return false;
@@ -207,7 +207,7 @@ bool QueryJob::write(Location location, Flags<WriteFlag> flags)
     return write(out, flags);
 }
 
-bool QueryJob::write(const Symbol &symbol, Flags<WriteFlag> writeFlags)
+bool QueryJob::write(const Symbol &symbol, const Flags<WriteFlag>& writeFlags)
 {
     Flags<Symbol::ToStringFlag> toStringFlags;
     if (queryFlags() & QueryMessage::SymbolInfoIncludeTargets)

--- a/src/QueryJob.h
+++ b/src/QueryJob.h
@@ -42,7 +42,7 @@ public:
     enum { Priority = 10 };
     QueryJob(const std::shared_ptr<QueryMessage> &msg,
              const std::shared_ptr<Project> &proj,
-             Flags<JobFlag> jobFlags = Flags<JobFlag>());
+             const Flags<JobFlag>& jobFlags = Flags<JobFlag>());
     virtual ~QueryJob();
 
     bool hasFilter() const { return mFileFilter || !mFilters.isEmpty(); }
@@ -64,8 +64,8 @@ public:
         Unfiltered = 0x04,
         NoContext = 0x08
     };
-    bool write(const String &out, Flags<WriteFlag> flags = Flags<WriteFlag>());
-    bool write(const Symbol &symbol, Flags<WriteFlag> writeFlags = Flags<WriteFlag>());
+    bool write(const String &out, const Flags<WriteFlag>& flags = Flags<WriteFlag>());
+    bool write(const Symbol &symbol, const Flags<WriteFlag>& writeFlags = Flags<WriteFlag>());
     bool write(Location location, Flags<WriteFlag> writeFlags = Flags<WriteFlag>());
     enum LocationPiece {
         Piece_Location,
@@ -77,7 +77,7 @@ public:
     };
     bool locationToString(Location location,
                           const std::function<void(LocationPiece, const String &)> &cb,
-                          Flags<WriteFlag> writeFlags = Flags<WriteFlag>());
+                          const Flags<WriteFlag>& writeFlags = Flags<WriteFlag>());
 
     template <int StaticBufSize>
     bool write(Flags<WriteFlag> writeFlags, const char *format, ...) RCT_PRINTF_WARNING(3, 4);
@@ -137,7 +137,7 @@ private:
     mutable std::mutex mMutex;
     bool mAborted;
     int mLinesWritten;
-    bool writeRaw(const String &out, Flags<WriteFlag> flags);
+    bool writeRaw(const String &out, const Flags<WriteFlag>& flags);
     std::shared_ptr<QueryMessage> mQueryMessage;
     Flags<JobFlag> mJobFlags;
     Signal<std::function<void(const String &)> > mOutput;

--- a/src/QueryMessage.cpp
+++ b/src/QueryMessage.cpp
@@ -45,7 +45,7 @@ void QueryMessage::decode(Deserializer &deserializer)
         ;
 }
 
-Flags<Location::ToStringFlag> QueryMessage::locationToStringFlags(Flags<Flag> queryFlags)
+Flags<Location::ToStringFlag> QueryMessage::locationToStringFlags(const Flags<Flag>& queryFlags)
 {
     Flags<Location::ToStringFlag> ret;
     if (!(queryFlags & NoContext))

--- a/src/QueryMessage.h
+++ b/src/QueryMessage.h
@@ -231,7 +231,7 @@ public:
 
     void setFlag(Flag flag, bool on = true) { mFlags.set(flag, on); }
     static Flag flagFromString(const String &string);
-    static Flags<Location::ToStringFlag> locationToStringFlags(Flags<Flag> queryFlags);
+    static Flags<Location::ToStringFlag> locationToStringFlags(const Flags<Flag>& queryFlags);
     inline Flags<Location::ToStringFlag> locationToStringFlags() const { return locationToStringFlags(mFlags); }
 
     virtual void encode(Serializer &serializer) const override;

--- a/src/RClient.cpp
+++ b/src/RClient.cpp
@@ -342,7 +342,7 @@ RClient::~RClient()
     cleanupLogging();
 }
 
-void RClient::addQuery(QueryMessage::Type type, String &&query, Flags<QueryMessage::Flag> extraQueryFlags)
+void RClient::addQuery(QueryMessage::Type type, String &&query, const Flags<QueryMessage::Flag>& extraQueryFlags)
 {
     auto cmd = std::make_shared<QueryCommand>(type, std::move(query));
     cmd->extraQueryFlags = extraQueryFlags;
@@ -705,7 +705,7 @@ CommandLineParser::ParseStatus RClient::parse(size_t argc, char **argv)
             }
             break; }
         case UnsavedFile: {
-            const String arg(value);
+            const String& arg(value);
             const int colon = arg.lastIndexOf(':');
             if (colon == -1) {
                 return { String::format<1024>("Can't parse -u [%s]", value.constData()), CommandLineParser::Parse_Error };

--- a/src/RClient.h
+++ b/src/RClient.h
@@ -197,7 +197,7 @@ public:
 #endif
 private:
     void addQuery(QueryMessage::Type t, String &&query = String(),
-                  Flags<QueryMessage::Flag> extraQueryFlags = Flags<QueryMessage::Flag>());
+                  const Flags<QueryMessage::Flag>& extraQueryFlags = Flags<QueryMessage::Flag>());
     void addQuitCommand(int exitCode);
 
     void addLog(LogLevel level);

--- a/src/RTags.cpp
+++ b/src/RTags.cpp
@@ -96,7 +96,7 @@ Path encodeSourceFilePath(const Path &dataDir, const Path &project, uint32_t fil
     return str;
 }
 
-Path findAncestor(Path path, const String &fn, Flags<FindAncestorFlag> flags, SourceCache *cache)
+Path findAncestor(const Path& path, const String &fn, const Flags<FindAncestorFlag>& flags, SourceCache *cache)
 {
     Path *cacheResult = 0;
     if (cache) {
@@ -174,7 +174,7 @@ Map<String, String> rtagsConfig(const Path &path, SourceCache *cache)
         if (cache) {
             auto it = cache->rtagsConfigCache.find(dir);
             if (it != cache->rtagsConfigCache.end()) {
-                for (const auto entry : it->second) {
+                for (const auto &entry : it->second) {
                     auto &ref = ret[entry.first];
                     if (ref.isEmpty())
                         ref = entry.second;
@@ -429,7 +429,7 @@ String eatString(CXString str)
     return ret;
 }
 
-String cursorToString(CXCursor cursor, Flags<CursorToStringFlags> flags)
+String cursorToString(CXCursor cursor, const Flags<CursorToStringFlags>& flags)
 {
     const CXCursorKind kind = clang_getCursorKind(cursor);
     String ret;
@@ -531,7 +531,7 @@ std::shared_ptr<TranslationUnit> TranslationUnit::load(const Path &path)
 
 std::shared_ptr<TranslationUnit> TranslationUnit::create(const Path &sourceFile, const List<String> &args,
                                                          CXUnsavedFile *unsaved, int unsavedCount,
-                                                         Flags<CXTranslationUnit_Flags> translationUnitFlags,
+                                                         const Flags<CXTranslationUnit_Flags>& translationUnitFlags,
                                                          bool displayDiagnostics)
 
 {

--- a/src/RTags.h
+++ b/src/RTags.h
@@ -145,7 +145,7 @@ enum CursorToStringFlags {
     AllCursorToStringFlags = IncludeUSR|IncludeRange|IncludeSpecializedUsr
 };
 RCT_FLAGS(CursorToStringFlags);
-String cursorToString(CXCursor cursor, Flags<CursorToStringFlags> = DefaultCursorToStringFlags);
+String cursorToString(CXCursor cursor, const Flags<CursorToStringFlags>& = DefaultCursorToStringFlags);
 
 RCT_FLAGS(CXTranslationUnit_Flags);
 
@@ -178,7 +178,7 @@ struct TranslationUnit {
                                                    const List<String> &args,
                                                    CXUnsavedFile *unsaved,
                                                    int unsavedCount,
-                                                   Flags<CXTranslationUnit_Flags> translationUnitFlags = CXTranslationUnit_None,
+                                                   const Flags<CXTranslationUnit_Flags>& translationUnitFlags = CXTranslationUnit_None,
                                                    bool displayDiagnostics = true);
 
     static std::shared_ptr<TranslationUnit> load(const Path &path);
@@ -765,7 +765,7 @@ enum FindAncestorFlag {
     Authoritative = 0x4
 };
 RCT_FLAGS(FindAncestorFlag);
-Path findAncestor(Path path, const String &fn, Flags<FindAncestorFlag> flags, SourceCache *cache = 0);
+Path findAncestor(const Path& path, const String &fn, const Flags<FindAncestorFlag>& flags, SourceCache *cache = 0);
 Map<String, String> rtagsConfig(const Path &path, SourceCache *cache = 0);
 
 enum { DefinitionBit = 0x1000 };

--- a/src/ReferencesJob.cpp
+++ b/src/ReferencesJob.cpp
@@ -19,7 +19,7 @@
 #include "RTags.h"
 #include "Server.h"
 
-static inline Flags<QueryJob::JobFlag> jobFlags(Flags<QueryMessage::Flag> queryFlags)
+static inline Flags<QueryJob::JobFlag> jobFlags(const Flags<QueryMessage::Flag>& queryFlags)
 {
     return (queryFlags & QueryMessage::Elisp ? Flags<QueryJob::JobFlag>(QueryJob::QuoteOutput) : Flags<QueryJob::JobFlag>());
 }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -417,7 +417,7 @@ String Server::guessArguments(const String &args, const Path &pwd, const Path &p
     Set<Path> includePaths;
     List<String> ret;
     bool hasInput = false;
-    Set<String> roots;
+    Set<Path> roots;
     if (!projectRootOverride.isEmpty())
         roots.insert(projectRootOverride.ensureTrailingSlash());
     ret << "/usr/bin/g++"; // this should be clang on mac

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -128,7 +128,7 @@ static inline String trim(const char *start, int size)
     return String(start, size);
 }
 
-static inline size_t hashIncludePaths(const List<Source::Include> &includes, const Path &buildRoot, Flags<Server::Option> flags)
+static inline size_t hashIncludePaths(const List<Source::Include> &includes, const Path &buildRoot, const Flags<Server::Option>& flags)
 {
     size_t hash = 0;
     std::hash<Path> hasher;
@@ -330,7 +330,7 @@ enum Mode {
 };
 static std::pair<Path, bool> resolveCompiler(const Path &unresolved,
                                              const Path &cwd,
-                                             const List<String> environment,
+                                             const List<String>& environment,
                                              const List<Path> &pathEnvironment,
                                              SourceCache *cache)
 {
@@ -720,7 +720,7 @@ SourceList Source::parse(const String &cmdLine,
         includePathHash = ::hashIncludePaths(includePaths, buildRoot, serverFlags);
 
         ret.reserve(inputs.size());
-        for (const auto input : inputs) {
+        for (const auto& input : inputs) {
             unresolvedInputLocations->append(input.absolute);
             if (input.unmolested == "-")
                 continue;
@@ -780,7 +780,7 @@ static inline bool compareDefinesNoNDEBUG(const Set<Source::Define> &l, const Se
 
 static bool nextArg(List<String>::const_iterator &it,
                     const List<String>::const_iterator end,
-                    Flags<Server::Option> flags)
+                    const Flags<Server::Option>& flags)
 {
     while (it != end) {
         if (isBlacklisted(*it)) {

--- a/src/Symbol.cpp
+++ b/src/Symbol.cpp
@@ -36,8 +36,8 @@ static inline const char *linkageSpelling(CXLinkageKind kind)
 }
 
 String Symbol::toString(const std::shared_ptr<Project> &project,
-                        Flags<ToStringFlag> cursorInfoFlags,
-                        Flags<Location::ToStringFlag> locationToStringFlags,
+                        const Flags<ToStringFlag>& cursorInfoFlags,
+                        const Flags<Location::ToStringFlag>& locationToStringFlags,
                         const Set<String> &pieceFilters) const
 {
     auto filterPiece = [&pieceFilters](const char *name) { return pieceFilters.isEmpty() || pieceFilters.contains(name); };
@@ -262,7 +262,7 @@ bool Symbol::isContainer() const
 }
 
 Value Symbol::toValue(const std::shared_ptr<Project> &project,
-                      Flags<ToStringFlag> toStringFlags,
+                      const Flags<ToStringFlag>& toStringFlags,
                       Flags<Location::ToStringFlag> locationToStringFlags,
                       const Set<String> &pieceFilters) const
 {

--- a/src/Symbol.h
+++ b/src/Symbol.h
@@ -166,12 +166,12 @@ struct Symbol
 
     };
     Value toValue(const std::shared_ptr<Project> &project,
-                  Flags<ToStringFlag> toStringFlags,
+                  const Flags<ToStringFlag>& toStringFlags,
                   Flags<Location::ToStringFlag> locationToStringFlags,
                   const Set<String> &pieceFilters) const;
     String toString(const std::shared_ptr<Project> &project = std::shared_ptr<Project>(),
-                    Flags<ToStringFlag> toStringFlags = DefaultFlags,
-                    Flags<Location::ToStringFlag> = Flags<Location::ToStringFlag>(),
+                    const Flags<ToStringFlag>& toStringFlags = DefaultFlags,
+                    const Flags<Location::ToStringFlag>& = Flags<Location::ToStringFlag>(),
                     const Set<String> &pieceFilters = Set<String>()) const;
     String kindSpelling() const { return kindSpelling(kind); }
     String displayName() const;


### PR DESCRIPTION
Fixed issues found by clang-tidy when running with `-checks=performance-*`. There were also some issues found in rct, but I chose to exclude them. If you're interested in those, too, let me know and I can re-run clang-tidy in the rct repo.