### PR TITLE
Making Rtags build with libc2.5 and some bug fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@
 
 sudo: required
 dist: trusty
+group: deprecated-2017Q4
 
 language: cpp
 

--- a/src/RClient.cpp
+++ b/src/RClient.cpp
@@ -481,7 +481,7 @@ CommandLineParser::ParseStatus RClient::parse(size_t argc, char **argv)
             if (colon == -1) {
                 return { String::format<1024>("invalid --socket-address %s\n", mTcpHost.constData()), CommandLineParser::Parse_Error };
             }
-            mTcpPort = atoi(value.constData() + colon + 1);
+            mTcpPort = atoi(mTcpHost.constData() + colon + 1);
             if (!mTcpPort) {
                 return { String::format<1024>("invalid --socket-address %s", mTcpHost.constData()), CommandLineParser::Parse_Error };
             }
@@ -610,7 +610,7 @@ CommandLineParser::ParseStatus RClient::parse(size_t argc, char **argv)
         case DependencyFilter: {
             Path p = std::move(value);
             if (!p.isFile()) {
-                return { String::format<1024>("%s doesn't seem to be a file", value.constData()), CommandLineParser::Parse_Error };
+                return { String::format<1024>("%s doesn't seem to be a file", p.constData()), CommandLineParser::Parse_Error };
             }
             mPathFilters.insert({ Path::resolved(p), QueryMessage::PathFilter::Dependency });
             break; }
@@ -1044,7 +1044,7 @@ CommandLineParser::ParseStatus RClient::parse(size_t argc, char **argv)
             }
             p.resolve(Path::MakeAbsolute);
             if (!p.exists()) {
-                return { String::format<1024>("%s does not seem to exist", value.constData()), CommandLineParser::Parse_Error };
+                return { String::format<1024>("%s does not seem to exist", p.constData()), CommandLineParser::Parse_Error };
             }
             if (p.isDir() && !p.endsWith('/'))
                 p.append('/');
@@ -1053,7 +1053,7 @@ CommandLineParser::ParseStatus RClient::parse(size_t argc, char **argv)
         case ProjectRoot: {
             Path p = std::move(value);
             if (!p.isDir()) {
-                return { String::format<1024>("%s does not seem to be a directory", value.constData()), CommandLineParser::Parse_Error };
+                return { String::format<1024>("%s does not seem to be a directory", p.constData()), CommandLineParser::Parse_Error };
             }
 
             p.resolve(Path::MakeAbsolute);
@@ -1070,7 +1070,7 @@ CommandLineParser::ParseStatus RClient::parse(size_t argc, char **argv)
             if (!p.isEmpty() && p != "clear" && p != "all") {
                 p.resolve(Path::MakeAbsolute);
                 if (!p.isFile()) {
-                    return { String::format<1024>("%s is not a file", value.constData()), CommandLineParser::Parse_Error };
+                    return { String::format<1024>("%s is not a file", p.constData()), CommandLineParser::Parse_Error };
                 }
                 if (idx + 1 < arguments.size()) {
                     if (arguments[idx + 1] == "on" || arguments[idx + 1] == "off") {
@@ -1142,7 +1142,7 @@ CommandLineParser::ParseStatus RClient::parse(size_t argc, char **argv)
         case FixIts: {
             Path p = std::move(value);
             if (!p.exists()) {
-                return { String::format<1024>("%s does not exist", value.constData()), CommandLineParser::Parse_Error };
+                return { String::format<1024>("%s does not exist", p.constData()), CommandLineParser::Parse_Error };
             }
 
             if (!p.isAbsolute())
@@ -1150,7 +1150,7 @@ CommandLineParser::ParseStatus RClient::parse(size_t argc, char **argv)
 
             if (p.isDir()) {
                 if (type != IsIndexed) {
-                    return { String::format<1024>("%s is not a file", value.constData()), CommandLineParser::Parse_Error };
+                    return { String::format<1024>("%s is not a file", p.constData()), CommandLineParser::Parse_Error };
                 } else if (!p.endsWith('/')) {
                     p.append('/');
                 }
@@ -1199,7 +1199,7 @@ CommandLineParser::ParseStatus RClient::parse(size_t argc, char **argv)
         case Dependencies: {
             Path p = std::move(value);
             if (!p.isFile()) {
-                return { String::format<1024>("%s is not a file", value.constData()), CommandLineParser::Parse_Error };
+                return { String::format<1024>("%s is not a file", p.constData()), CommandLineParser::Parse_Error };
             }
             p.resolve();
             List<String> args;
@@ -1246,7 +1246,7 @@ CommandLineParser::ParseStatus RClient::parse(size_t argc, char **argv)
             Path p = std::move(value);
             p.resolve(Path::MakeAbsolute);
             if (!p.isFile()) {
-                return { String::format<1024>("%s is not a file", value.constData()), CommandLineParser::Parse_Error };
+                return { String::format<1024>("%s is not a file", p.constData()), CommandLineParser::Parse_Error };
             }
             addQuery(QueryMessage::PreprocessFile, std::move(p));
             break; }
@@ -1266,7 +1266,7 @@ CommandLineParser::ParseStatus RClient::parse(size_t argc, char **argv)
             Path p = std::move(value);
             p.resolve(Path::MakeAbsolute);
             if (!p.isFile()) {
-                return { String::format<1024>("%s is not a file", value.constData()), CommandLineParser::Parse_Error };
+                return { String::format<1024>("%s is not a file", p.constData()), CommandLineParser::Parse_Error };
             }
             addQuery(QueryMessage::VisitAST, std::move(p));
 #endif

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -289,8 +289,8 @@ static inline bool isCompiler(const Path &fullPath, const List<String> &environm
         return ret;
 
     char path[PATH_MAX];
-    strcpy(path, "/tmp/rtags-compiler-check-XXXXXX.c");
-    const int fd = mkstemps(path, 2);
+    strcpy(path, "/tmp/rtags-compiler-check-XXXXXX");
+    const int fd = mkstemp(path);
     if (fd == -1) {
         error("Failed to make temporary file errno: %d", errno);
         return false;


### PR DESCRIPTION
For unspeakable reasons I need to be able to build and run rtags in a libc2.5 environment.  The mkstemps symbol does not
exist in libc2.5, but the suffix isn't actually necessary so we can use mkstemp which does exist.

In the process of using rtags, I noticed that some options (specifically --socket-address in my case) were failing with
parser errors although they parsed fine in newer libcs:

```
$ ./rc --socket-address 127.0.0.1:123
invalid --socket-address 127.0.0.1:123
Try 'rc --help' for more information.
```

In investigating why, I found a case of undefined behavior: we were accessing an std::string that we had moved out
of. The reason it works in newer libcs was because the small string optimization was hiding it - in most cases that move
was actually a copy. When we use a long domain name, we get the same parsing issue in modern libcs:

```
$ ./rc --socket-address really-long-domain-name:123
invalid --socket-address really-long-domain-name:123
Try 'rc --help' for more information.
```

Fixes #1114

Also added `group: deprecated-2017Q4` - our travis does not seem to work with the latest trusty image.

I went through RClient.cpp and fixed a few spots where we have the same issue.