### PR TITLE
rtags.el: errmsg handling, diagnostics, mode-line, key bindings, face…

### DIFF
--- a/src/rtags.el
+++ b/src/rtags.el
@@ -3030,9 +3030,11 @@ can be specified with a prefix argument."
 (defun rtags--mode-line-diag-string ()
   (and rtags--diagnostics-count
        (> rtags--diagnostics-count 0)
-       (propertize
-        (format "%d diag%s" rtags--diagnostics-count (if (> rtags--diagnostics-count 1) "s" ""))
-        'face 'rtags-errline)))
+       (propertize (format "%d diag%s" rtags--diagnostics-count
+                           (if (> rtags--diagnostics-count 1) "s" ""))
+                   'face 'rtags-errline
+                   'mouse-face 'mode-line-highlight
+                   'local-map (make-mode-line-mouse-map 'mouse-1 'rtags-diagnostics))))
 
 (defun rtags-mode-line ()
   "Return the RTags diagnostics (warning, error, fixit) count to

--- a/src/rtags.el
+++ b/src/rtags.el
@@ -309,7 +309,7 @@ the Customize interface, `rtags-set-periodic-reparse-timeout',
 ;; Leveraging rtags-socket-file
 ;; ----------------------------
 ;; One approach to handling multiple projects is to have separate rdm tag
-;; servers, on per project. Consider a project with many thousands of files
+;; servers, one per project. Consider a project with many thousands of files
 ;; (thousands of .so's). The size of the rdm tag database on disk will be
 ;; several GBs. Each project is in it's own workspace on disk often referred to
 ;; as a sandbox.  Having one rdm tag server for sandbox helps with scalability.
@@ -369,12 +369,23 @@ the Customize interface, `rtags-set-periodic-reparse-timeout',
   :safe 'stringp)
 
 (defcustom rtags-error-message-function 'rtags-error-message-default
-  "Function rtags.el calls to produce errors messages"
+  "Function rtags.el calls to produce errors messages
+
+This defaults to `rtags-error-message-default'. You provide
+a function that takes an error type and should return the
+appropriate format string for `error'. For example,
+
+(defun my-rtags-error-message-function (type)
+  \"Customize messages produced by RTags\"
+  (cond ((eq type 'rtags-rdm-not-running)
+         \"Unable to connect to the RTags server. See BLAH to start it\")
+        (t
+         (rtags-error-message-default type))))"
   :group 'rtags
   :type 'function)
 
 (defcustom rtags-find-file-prompt "Find files"
-  "What prompt to use for ‘rtags-find-file’."
+  "What prompt to use for `rtags-find-file'."
   :group 'rtags
   :type 'string
   :type 'stringp)
@@ -466,6 +477,17 @@ on intervals."
   "Run after diagnostics have been parsed."
   :group 'rtags
   :type 'hook)
+
+(defcustom rtags-diagnostics-summary-in-mode-line t
+  "Display diagnostics count (warnings, errors, fixits) in the mode line"
+  :group 'rtags
+  :type 'boolean
+  :set (lambda (var val)
+         (set var val)
+         (if val
+             (add-to-list 'global-mode-string '(:eval (rtags-mode-line)))
+           (setq global-mode-string (delete '(:eval (rtags-mode-line)) global-mode-string))
+             )))
 
 (defcustom rtags-completions-hook nil
   "Run after completions have been parsed."
@@ -636,7 +658,7 @@ Note: It is recommended to run each sandbox is separate Emacs process."
   :safe 'booleanp)
 
 (defcustom rtags-display-result-backend 'default
-  "Method to use to diplay RTags results, like references."
+  "Method to use to display RTags results, like references."
   :type '(choice (const :tag "RTags (default)" default)
                  (const :tag "Helm" helm)
                  (const :tag "Ivy" ivy))
@@ -645,7 +667,7 @@ Note: It is recommended to run each sandbox is separate Emacs process."
   :risky t)
 
 (defcustom rtags-imenu-kind-filter "-references,-vardecl,-parmdecl,-inclusiondirective,-*literal*,-enumconstantdecl,-classdecl-,-structdecl-,-classtemplate-,-statements,-lambdaexpr"
-  "Argument passed to --kind-filter for ‘rtags-imenu’."
+  "Argument passed to --kind-filter for `rtags-imenu'."
   :group 'rtags
   :type 'string
   :safe 'stringp)
@@ -681,24 +703,36 @@ of the package `multiple-cursors', if it is installed."
 (defface rtags-context nil "Context" :group 'rtags)
 
 (defface rtags-warnline
-  '((((supports :underline (:style wave)))
-     :underline (:style wave :color "orange"))
+  '((((class color) (background light) (supports :underline (:style wave)))
+     :underline (:style wave :color "black")
+     :foreground "black" :background "yellow")
+    (((class color) (background dark) (supports :underline (:style wave)))
+     :underline (:style wave :color "white")
+     :foreground "white" :background "OrangeRed")
     (t
      :underline t :inherit error))
   "Face used for marking error lines."
   :group 'rtags)
 
 (defface rtags-errline
-  '((((supports :underline (:style wave)))
-     :underline (:style wave :color "red"))
+  '((((class color) (background light) (supports :underline (:style wave)))
+     :underline (:style wave :color "red")
+     :foreground "red" :background "yellow")
+    (((class color) (background dark) (supports :underline (:style wave)))
+     :underline (:style wave :color "white")
+     :foreground "white" :background "red")
     (t
      :underline t :inherit error))
   "Face used for marking warning lines."
   :group 'rtags)
 
 (defface rtags-fixitline
-  '((((supports :underline (:style wave)))
-     :underline (:style wave :color "chartreuse3"))
+  '((((class color) (background light) (supports :underline (:style wave)))
+     :underline (:style wave :color "brown")
+     :foreground "brown" :background "yellow" :slant italic)
+    (((class color) (background dark) (supports :underline (:style wave)))
+     :underline (:style wave :color "white")
+     :foreground "white" :background "brown" :slant italic)
     (t
      :underline t :inherit error))
   "Face used for marking fixit lines."
@@ -1331,7 +1365,7 @@ to only call this when `rtags-socket-file' is defined.
                        (erase-buffer))
                      (setq rtags-last-request-not-connected t)
                      (unless noerror
-                       (error "Can't seem to connect to server. Is rdm running?")))
+                       (rtags--error 'rtags-rdm-not-running)))
                     ((= result rtags-exit-code-protocol-failure)
                      (when output
                        (erase-buffer))
@@ -1340,7 +1374,7 @@ to only call this when `rtags-socket-file' is defined.
                                       "and installing a new rtags build that modified the protocol. They need to be in sync."))))
                     ((= result rtags-exit-code-not-indexed)
                      (unless noerror
-                       (message "%s not indexed" (or path "buffer")))
+                       (rtags--message 'rtags-file-not-indexed (or path "buffer")))
                      (erase-buffer)
                      (setq rtags-last-request-not-indexed t))
                     (t)))) ;; other error
@@ -2442,7 +2476,7 @@ of PREFIX or not, if doesn't contain one, one will be added."
   (define-key map (kbd (concat prefix ";")) 'rtags-find-file)
   (define-key map (kbd (concat prefix "F")) 'rtags-fixit)
   (define-key map (kbd (concat prefix "L")) 'rtags-copy-and-print-current-location)
-  (define-key map (kbd (concat prefix "X")) 'rtags-fix-fixit-at-point)
+  (define-key map (kbd (concat prefix "X")) 'rtags-apply-fixit-at-point)
   (define-key map (kbd (concat prefix "B")) 'rtags-show-rtags-buffer)
   (define-key map (kbd (concat prefix "K")) 'rtags-make-member)
   (define-key map (kbd (concat prefix "I")) 'rtags-imenu)
@@ -2467,8 +2501,7 @@ of PREFIX or not, if doesn't contain one, one will be added."
    ["Find references at point" rtags-find-references-at-point]
    ["Find symbol definition by name" rtags-find-symbol]
    ["Find reference by name" rtags-find-references]
-   ["Find all definitions, references, etc. at point"
-    rtags-find-all-references-at-point]
+   ["Find all definitions, references, etc. at point" rtags-find-all-references-at-point]
    ["Find symbol declaration at point" rtags-guess-function-at-point]
    ["Find virtual method implementations at point" rtags-find-virtuals-at-point]
    ["Find file in RTags database" rtags-find-file]
@@ -2482,10 +2515,10 @@ of PREFIX or not, if doesn't contain one, one will be added."
    ["Print class hierarchy" rtags-print-class-hierarchy]
    "--"
    ["Show compiler diagnostic messages" rtags-diagnostics]
+   ["Cycle though diagnostic messages" rtags-cycle-overlays-on-screen]
+   ["Apply all compiler fix-its" rtags-fixit]
+   ["Apply compiler fix-it at point" rtags-apply-fixit-at-point]
    ["Compile file" rtags-compile-file]
-   ["Cycle though diagnostic overlays" rtags-cycle-overlays-on-screen]
-   ["Apply compiler fix-it" rtags-fixit]
-   ["Apply compiler fix-it at point"  rtags-fixit-at-point]
    "--"
    ["Rename symbol" rtags-rename-symbol]
    ["Make stub member function" rtags-make-member]
@@ -2626,7 +2659,7 @@ treated as references to the referenced symbol."
 
 ;;;###autoload
 (defun rtags-find-virtuals-at-point (&optional prefix)
-  "List all reimplentations of function under cursor.
+  "List all reimplementations of function under cursor.
 This includes both declarations and definitions."
   (interactive "P")
   (let ((otherwindow (and prefix (listp prefix)))
@@ -2847,7 +2880,7 @@ replacement and then ask for confirmation.  However, when the scope
 of the symbol at point is just one file (the file that's being
 visited by current buffer), the variable `rtags-use-multiple-cursors'
 is non-nil and the `multiple-cursors' package is available, then this
-function will create fake cursors at all occurances of the symbol.
+function will create fake cursors at all occurrences of the symbol.
 
 The optional argument NO-CONFIRM means agree to all replacements and
 can be specified with a prefix argument."
@@ -2987,42 +3020,44 @@ can be specified with a prefix argument."
         (erase-buffer)
         (setq buffer-read-only t)))))
 
-(defvar rtags-error-warning-count nil)
-(make-variable-buffer-local 'rtags-error-warning-count)
+(defvar rtags--diagnostics-count nil)
+(make-variable-buffer-local 'rtags--diagnostics-count)
 
 (defvar rtags-last-index nil)
 (defvar rtags-last-total nil)
 (defvar rtags-remaining-jobs nil)
 
-(defun rtags-modeline-format-helper (type count)
-  (and (> count 0)
-       (format "%d %s%s" count type (if (> count 1) "s" ""))))
+(defun rtags--mode-line-diag-string ()
+  (and rtags--diagnostics-count
+       (> rtags--diagnostics-count 0)
+       (propertize
+        (format "%d diag%s" rtags--diagnostics-count (if (> rtags--diagnostics-count 1) "s" ""))
+        'face 'rtags-errline)))
 
-(defun rtags-modeline()
+(defun rtags-mode-line ()
+  "Return the RTags diagnostics (warning, error, fixit) count to
+display in the mode-line. See
+`rtags-diagnostics-summary-in-mode-line'"
   (let* ((progress
           (and rtags-remaining-jobs
                (> rtags-remaining-jobs 0)
                (format "%d/%d %d%%%% (%d left)" rtags-last-index rtags-last-total (/ (* rtags-last-index 100) rtags-last-total) rtags-remaining-jobs)))
-         (errors (if rtags-error-warning-count
-                     (car rtags-error-warning-count)
-                   0))
-         (warnings (if rtags-error-warning-count
-                       (cdr rtags-error-warning-count)
-                     0))
-         (errorsString (rtags-modeline-format-helper "error" errors))
-         (warningsString (rtags-modeline-format-helper "warning" warnings))
-         (errors-warnings
-          (cond ((and errorsString warningsString) (concat errorsString "/" warningsString))
-                (errorsString)
-                (warningsString)
-                (t nil))))
-    (cond ((and progress errors-warnings) (format "RTags: %s %s " progress errors-warnings))
+         (diag-string (rtags--mode-line-diag-string)))
+    (cond ((and progress diag-string) (format "RTags: %s [%s] " progress diag-string))
           (progress (format "RTags: %s " progress))
-          (errors-warnings (format "RTags: %s " errors-warnings))
+          (diag-string (format "[%s] " diag-string))
           (t ""))))
 
-(defvar rtags-error-warning-count nil)
-(make-variable-buffer-local 'rtags-error-warning-count)
+(defvar rtags--diagnostics-count nil)
+(make-variable-buffer-local 'rtags--diagnostics-count)
+
+(defun rtags--inc-diagnostics-count ()
+  "Increment `rtags--diagnostics-count' used in mode-line display
+of diagnostics count"
+  (if rtags--diagnostics-count
+      (incf rtags--diagnostics-count)
+    (setq rtags--diagnostics-count 1)))
+
 
 (defun rtags-handle-check-style (filename data)
   ;; (message "parsing nodes %s" (rtags-buffer-file-name buffer))
@@ -3060,16 +3095,13 @@ can be specified with a prefix argument."
           (overlay-put overlay 'rtags-error-end end)
           ;; (message "Got overlay %s:%d:%d %d - %d-%d - %s" filename line column (or length -1) start end severity)
           (overlay-put overlay 'face (cond ((eq severity 'error)
-                                            (if rtags-error-warning-count
-                                                (incf (car rtags-error-warning-count))
-                                              (setq rtags-error-warning-count (cons 1 0)))
+                                            (rtags--inc-diagnostics-count)
                                             'rtags-errline)
                                            ((eq severity 'warning)
-                                            (if rtags-error-warning-count
-                                                (incf (cdr rtags-error-warning-count))
-                                              (setq rtags-error-warning-count (cons 0 1)))
+                                            (rtags--inc-diagnostics-count)
                                             'rtags-warnline)
                                            ((eq severity 'fixit)
+                                            (rtags--inc-diagnostics-count)
                                             (overlay-put overlay 'priority 1)
                                             'rtags-fixitline)
                                            ((eq severity 'skipped)
@@ -3111,7 +3143,7 @@ can be specified with a prefix argument."
       (when buf
         (with-current-buffer buf
           (rtags-overlays-remove)
-          (setq rtags-error-warning-count nil)
+          (setq rtags--diagnostics-count nil)
           (rtags-overlays-buffers-set buf diags)
           (dolist (diag diags)
             (rtags-handle-check-style file diag))
@@ -3157,6 +3189,8 @@ can be specified with a prefix argument."
                      rtags-remaining-jobs (nth 3 data)))
               (t))
         (run-hooks 'rtags-diagnostics-hook)
+        (if rtags-diagnostics-summary-in-mode-line
+            (force-mode-line-update))
         (forward-char 1)
         (delete-region (point-min) (point))))))
 
@@ -5198,9 +5232,26 @@ the user enter missing field manually."
       (set-process-sentinel rtags-install-process 'rtags-install-process-sentinel)
       (set-process-filter rtags-install-process 'rtags-install-process-filter))))
 
+(defun rtags--error (type &rest error-args)
+  "Call `rtags-error-message-function' with `type' to get the
+format string for `error' and call it with ERROR-ARGS"
+  (let ((format-string (funcall rtags-error-message-function type)))
+    (if (not format-string)
+        (error "assert - unable to get error string for %S" type))
+    (apply #'error format-string error-args)))
+
+(defun rtags--message (type &rest message-args)
+  "Call `rtags-error-message-function' with `type' to get the
+format string for `message' and call it with MESSAGE-ARGS"
+  (let ((format-string (funcall rtags-error-message-function type)))
+    (if (not format-string)
+        (error "assert - unable to get message string for %S" type))
+    (apply #'message format-string message-args)))
 
 (defun rtags-error-message-default (type)
-  (cond ((eq type 'rtags-socket-file-doesnt-exist) "RTags: %S does not exist")
+  (cond ((eq type 'rtags-rdm-not-running) "Can't seem to connect to server. Is rdm running?")
+        ((eq type 'rtags-file-not-indexed) "%s not indexed")
+        ((eq type 'rtags-socket-file-doesnt-exist) "RTags: %S does not exist")
         ((eq type 'rtags-cant-find-rc) "RTags: Can't fidn rc")
         ((eq type 'rtags-cant-connecto-to-server) "RTags: Can't seem to connect to server. Is rdm running?")
         ((eq type 'rtags-no-file-chosen) "RTags: No file chosen")
@@ -5214,7 +5265,7 @@ the user enter missing field manually."
         ((eq type 'rtags-cant-start-process) "RTags: Can't start the process `%s'. Please check the value of the variable `rtags-path'.")
         ((eq type 'rtags-malines-doesnt-work-with-location-length) "RTags: maxlines doesn't work with location/length")
         ((eq type 'rtags-buffer-is-not-visiting-a-file) "RTags: Buffer is not visiting a file")
-        ((eq type 'rtags-no-valid-incudes) "RTags: No valid includes found")
+        ((eq type 'rtags-no-valid-includes) "RTags: No valid includes found")
         ((eq type 'rtags-no-appropriate-symbol-that-I-know-of) "RTags: No appropriate symbol here that I know of")
         ((eq type 'rtags-is-already-implemented) "RTags: %s is already implemented here: %s")
         ((eq type 'rtags-cant-find-the-range) "RTags: Can't find the range")


### PR DESCRIPTION
Updates to rtags.el

- Implemented rtags-error-message-function handling. I saw this was partially implemented and
  I carried it forward a little more and added two more 'types' to it. Now one can customize the
  errors without modifying rtags.el itself.
    1. rtags-rdm-not-running
    2. rtags-file-not-indexed
  To finish the implementation, calls to `error' and `message' should be updated to use
  `rtags--error' and `rtags--message'.
- Added (defcustom rtags-diagnostics-summary-in-mode-line ...) which defaults to t and causes
  rtags to show diagnostic info in the summary line. Simplified to show total count rather
  than count of each class of diagnostic.
- Fixed the diagnostics count shown in summary line to include fixits, i.e. number of diagnostics,
  diags, is num warnings + num errors + num fixits.
- Fixed "X" key binding (was pointing at invalid function name). Also fixed wording in a couple
  menu items.
- Updated the rtags-warnline, rtags-errline, rtags-fixitline faces to look like highlighters where
  the highlight is slightly different for each face and depends upon whether or not a light
  or dark background is active.
- Fixed some typos and removed some unnecessary unicode characters.