### PR TITLE
Invoke ctest when running make install

### DIFF
--- a/README.org
+++ b/README.org
@@ -217,6 +217,15 @@ sudo port install clang-3.5
   Note that if you're trying to test RTags by indexing RTags' own
   source code you shouldn't build it in /tmp/ since RTags will refuse
   to index files in /tmp/
+  
+  "make install" runs ctest by default. If you want to skip ctest during install, 
+  you can pass -DSKIP_CTEST=True to cmake.
+
+  #+BEGIN_SRC sh
+  cmake .. -DSKIP_CTEST=True
+  make
+  make install
+  #+END_SRC
 
 - Elpa
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -323,6 +323,11 @@ install(TARGETS rdm rc rp RUNTIME DESTINATION bin COMPONENT rtags)
 install(FILES ../bin/gcc-rtags-wrapper.sh DESTINATION bin
     PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 install(FILES ../man/man7/rc.7 ../man/man7/rdm.7 DESTINATION share/man/man7/)
+
+if (UNIX AND NOT ${SKIP_CTEST})
+  install(CODE "execute_process(COMMAND ctest)")
+endif ()
+
 if (NOT RTAGS_NO_ELISP_FILES)
     install(FILES ${RTAGS_ELISP_SOURCES} DESTINATION ${RTAGS_ELISP_INSTALL_LOCATION})
 endif ()


### PR DESCRIPTION
Run ctest when running "make install" to ensure tests are not broken by new changes. Also added an option to cmake turn off ctest at install. Updated "Building RTags" section in README about this option.