### PR TITLE
rtags.el: rename face, error customization, prompting, and scopes

### DIFF
--- a/src/rtags.el
+++ b/src/rtags.el
@@ -2451,6 +2451,7 @@ of PREFIX or not, if doesn't contain one, one will be added."
     (setq prefix "C-c r "))
   (define-key map (kbd (concat prefix ".")) 'rtags-find-symbol-at-point)
   (define-key map (kbd (concat prefix ",")) 'rtags-find-references-at-point)
+  (define-key map (kbd (concat prefix "t")) 'rtags-references-tree)
   (define-key map (kbd (concat prefix "v")) 'rtags-find-virtuals-at-point)
   (define-key map (kbd (concat prefix "V")) 'rtags-print-enum-value-at-point)
   (define-key map (kbd (concat prefix "/")) 'rtags-find-all-references-at-point)
@@ -2497,6 +2498,7 @@ of PREFIX or not, if doesn't contain one, one will be added."
    submenu-name
    ["Find symbol definition at point" rtags-find-symbol-at-point]
    ["Find references at point" rtags-find-references-at-point]
+   ["Find references tree at point" rtags-references-tree]
    ["Find symbol definition by name" rtags-find-symbol]
    ["Find reference by name" rtags-find-references]
    ["Find all definitions, references, etc. at point" rtags-find-all-references-at-point]


### PR DESCRIPTION
1. Updated rtags-rename symbol confirmation buffer face, rtags-argument-face, to be readable on
   light backgrounds black on cyan instead of black on blue.
2. Replaced (error "format string" args) with (rtags--error 'type args) to allow for
   customization of error messages.
3. Made rtags-find-file and rtags-find-symbols-by-name-internal (used by rtags-find-symbol and
   rtags-find-references) place the default input in the mini-buffer positioned at end. This
   makes it easy to use the current symbol as a starting point for completion, e.g. if point is
   on MyFunction and you want to find MyFunction2, all you need to do is add the "2" and hit
   enter.
4. Updated rtags-current-token to return class scopes. This was done by adding ':' to the symbol
   characters used for matching the token. For example, if point is on any part of
   MyClass::Function, rtags-find-symbol will prompt with 'MyClass::Function' as the default
   symbol to find (previously it would prompt with MyClass or Function).
   I do see that rtags-current-token is called from many locations and have tried to test
   each, but am not 100% positive adding ':' to the characters to match is okay.