### PR TITLE
fixed scoping on an ifdef

### DIFF
--- a/src/RTags.cpp
+++ b/src/RTags.cpp
@@ -877,8 +877,9 @@ void DiagnosticsProvider::diagnose()
                     diag = std::move(it->second);
             }
         }
-#endif
     }
+#endif
+
 
 
 #if 0


### PR DESCRIPTION
Head on rtags fails to build on RHEL7.  This fixes that problem.