### PR TITLE
Added RTags::getArguments() to retrieve the function arguments.

### DIFF
--- a/src/AST.h
+++ b/src/AST.h
@@ -143,7 +143,7 @@ public:
             return ret;
         }
 
-        unsigned argumentCount() const { return data ? clang_Cursor_getNumArguments(data->cursor) : 0; }
+        unsigned argumentCount() const { return data ? RTags::getArguments(data->cursor) : 0; }
         inline Cursors arguments() const;
 
         int fieldBitWidth() const { return intProperty(&clang_getFieldDeclBitWidth); }
@@ -446,11 +446,12 @@ inline AST::Cursors AST::Cursor::arguments() const
 {
     AST::Cursors ret;
     if (data) {
-        const unsigned size = clang_Cursor_getNumArguments(data->cursor);
+	std::vector<CXCursor> args;
+        const unsigned size = RTags::getArguments(data->cursor, &args);
         if (size) {
             ret.resize(size);
             for (unsigned i=0; i<size; ++i) {
-                ret[i] = data->ast->create(clang_Cursor_getArgument(data->cursor, i));
+                ret[i] = data->ast->create(args[i]);
             }
         }
     }

--- a/src/ClangIndexer.cpp
+++ b/src/ClangIndexer.cpp
@@ -1473,11 +1473,12 @@ void ClangIndexer::handleBaseClassSpecifier(const CXCursor &cursor)
 void ClangIndexer::extractArguments(List<Symbol::Argument> *arguments, const CXCursor &cursor)
 {
     assert(arguments);
-    const int count = std::max(0, clang_Cursor_getNumArguments(cursor));
+    std::vector<CXCursor> args;
+    const int count = std::max(0, RTags::getArguments(cursor, &args));
     arguments->resize(count);
     for (int i=0; i<count; ++i) {
         auto &ref = (*arguments)[i];
-        CXCursor arg = clang_Cursor_getArgument(cursor, i);
+        CXCursor arg = args[i];
         CXSourceRange range = clang_getCursorExtent(arg);
         unsigned startOffset, endOffset;
 

--- a/src/RTags.h
+++ b/src/RTags.h
@@ -318,6 +318,8 @@ struct Auto {
 };
 bool resolveAuto(const CXCursor &cursor, Auto *a = 0);
 
+int getArguments(const CXCursor &cursor, std::vector<CXCursor> *args = 0);
+
 struct Filter
 {
     enum Mode {
@@ -362,7 +364,7 @@ struct Filter
         }
         if (argumentCount != -1) {
 #if CLANG_VERSION_MINOR > 1
-            return clang_Cursor_getNumArguments(cursor) == argumentCount;
+            return RTags::getArguments(cursor) == argumentCount;
 #else
             return true;
 #endif


### PR DESCRIPTION
"rc --symbol-info" can not retrieve the function arguments properly when used with template function.

The steps to reproduce is:
```c
$ cat test1.cpp
int fun1(int a) { return 0; }
$ rc --symbol-info test1.cpp:1:6 | grep Arguments
Arguments: int a
```
Arguments extracted successfully from function.

```c++
$ cat test2.cpp
template <type name T> int  func2(T a) { return 0; }
$ rc --symbol-info test2.cpp:1:30 | grep Arguments
```
No arguments extracted from template function.

This is because the following clang's APIs can not work with template function.
- clang_Cursor_counterarguments()
- clang_Cursor_get Argument()

This commit added RTags::getArguments() to solve this issue.