### PR TITLE
Exclude "skipped" diagnostics from rc's JSON output

### DIFF
--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -1354,6 +1354,9 @@ void Project::updateDiagnostics(uint32_t fileId, const Diagnostics &diagnostics)
                 //     error() << "continuing";
                 continue;
             }
+            if (it.second.flags & Diagnostic::Skipped) {
+                continue;
+            }
 
             const uint32_t f = it.first.fileId();
             if (lastFileId != f) {


### PR DESCRIPTION
* For any non-trivial project `--diagnose-all --json` takes an inordinate
amount of time.  The vast majority of time taken is the JSON construction.
* To mitigate this, exclude `Skipped` diagnostic types - which don't seem
to be very useful anyway - from the JSON output.