### PR TITLE
Add `--last-indexed` rc command giving last idle time of current project

### DIFF
--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -259,7 +259,7 @@ static void saveDependencies(DataFile &file, const Dependencies &dependencies)
 
 Project::Project(const Path &path)
     : mPath(path), mProjectDataDir(RTags::encodeSourceFilePath(Server::instance()->options().dataDir, path)),
-      mJobCounter(0), mJobsStarted(0), mBytesWritten(0), mSaveDirty(false)
+      mJobCounter(0), mJobsStarted(0), mLastIdleTime(time(0)), mBytesWritten(0), mSaveDirty(false)
 {
     mProjectFilePath = mProjectDataDir + "project";
     mSourcesFilePath = mProjectDataDir + "sources";
@@ -810,6 +810,7 @@ void Project::onJobFinished(const std::shared_ptr<IndexerJob> &job, const std::s
     }
 
     if (mActiveJobs.isEmpty()) {
+        mLastIdleTime = time(0);
         save();
         double timerElapsed = (mTimer.elapsed() / 1000.0);
         const double averageJobTime = timerElapsed / mJobsStarted;

--- a/src/Project.h
+++ b/src/Project.h
@@ -218,6 +218,7 @@ public:
     void clearWatch(Flags<WatchMode> mode);
     Hash<Path, Flags<WatchMode> > watchedPaths() const { return mWatchedPaths; }
 
+    time_t lastIdleTime() const { return mLastIdleTime; }
     bool isIndexing() const { return !mActiveJobs.isEmpty(); }
     void onFileAdded(const Path &path);
     void onFileModified(const Path &path);
@@ -436,6 +437,8 @@ private:
 
     Hash<uint32_t, Path> mVisitedFiles;
     int mJobCounter, mJobsStarted;
+
+    time_t mLastIdleTime;
 
     Diagnostics mDiagnostics;
 

--- a/src/QueryMessage.h
+++ b/src/QueryMessage.h
@@ -54,6 +54,7 @@ public:
         IsIndexed,
         IsIndexing,
         JobCount,
+        LastIndexed,
         ListSymbols,
         PreprocessFile,
         Project,

--- a/src/RClient.cpp
+++ b/src/RClient.cpp
@@ -75,6 +75,7 @@ std::initializer_list<CommandLineParser::Option<RClient::OptionType> > opts = {
     { RClient::Status, "status", 's', CommandLineParser::Optional, "Dump status of rdm. Arg can be symbols or symbolNames." },
     { RClient::Diagnose, "diagnose", 0, CommandLineParser::Required, "Resend diagnostics for file." },
     { RClient::DiagnoseAll, "diagnose-all", 0, CommandLineParser::NoValue, "Resend diagnostics for all files." },
+    { RClient::LastIndexed, "last-indexed", 0, CommandLineParser::NoValue, "Get timestamp of the last time indexing completed for the current project." },
     { RClient::IsIndexed, "is-indexed", 'T', CommandLineParser::Required, "Check if rtags knows about, and is ready to return information about, this source file." },
     { RClient::IsIndexing, "is-indexing", 0, CommandLineParser::NoValue, "Check if rtags is currently indexing files." },
     { RClient::HasFileManager, "has-filemanager", 0, CommandLineParser::Optional, "Check if rtags has info about files in this directory." },
@@ -1127,6 +1128,9 @@ CommandLineParser::ParseStatus RClient::parse(size_t argc, char **argv)
             break; }
         case IsIndexing: {
             addQuery(QueryMessage::IsIndexing);
+            break; }
+        case LastIndexed: {
+            addQuery(QueryMessage::LastIndexed);
             break; }
         case NoSortReferencesByInput: {
             mQueryFlags |= QueryMessage::NoSortReferencesByInput;

--- a/src/RClient.h
+++ b/src/RClient.h
@@ -94,6 +94,7 @@ public:
         JSON,
         JobCount,
         KindFilter,
+        LastIndexed,
         ListBuffers,
         ListCursorKinds,
         ListSymbols,

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -702,6 +702,9 @@ void Server::handleQueryMessage(const std::shared_ptr<QueryMessage> &message, co
     case QueryMessage::IsIndexing:
         isIndexing(message, conn);
         break;
+    case QueryMessage::LastIndexed:
+        lastIndexed(message, conn);
+        break;
     case QueryMessage::RemoveFile:
         removeFile(message, conn);
         break;
@@ -851,6 +854,24 @@ void Server::followLocation(const std::shared_ptr<QueryMessage> &query, const st
     } else {
         conn->finish(RTags::GeneralFailure);
     }
+}
+
+void Server::lastIndexed(const std::shared_ptr<QueryMessage> &query, const std::shared_ptr<Connection> &conn)
+{
+    // Path path = query->path();
+    const Match match = query->match();
+    std::shared_ptr<Project> project = projectForQuery(query);
+    if (!project)
+        project = currentProject();
+
+    if (!project) {
+        error("No project");
+        conn->finish();
+        return;
+    }
+
+    conn->write<128>("%ld", project->lastIdleTime());
+    conn->finish();
 }
 
 void Server::isIndexing(const std::shared_ptr<QueryMessage> &, const std::shared_ptr<Connection> &conn)

--- a/src/Server.h
+++ b/src/Server.h
@@ -179,6 +179,7 @@ private:
     void includeFile(const std::shared_ptr<QueryMessage> &query, const std::shared_ptr<Connection> &conn);
     void isIndexed(const std::shared_ptr<QueryMessage> &query, const std::shared_ptr<Connection> &conn);
     void isIndexing(const std::shared_ptr<QueryMessage> &, const std::shared_ptr<Connection> &conn);
+    void lastIndexed(const std::shared_ptr<QueryMessage> &, const std::shared_ptr<Connection> &conn);
     void jobCount(const std::shared_ptr<QueryMessage> &query, const std::shared_ptr<Connection> &conn);
     void listSymbols(const std::shared_ptr<QueryMessage> &query, const std::shared_ptr<Connection> &conn);
     void preprocessFile(const std::shared_ptr<QueryMessage> &query, const std::shared_ptr<Connection> &conn);


### PR DESCRIPTION
* When polling to check if editor updates are required, using e.g. `--is-indexing` has a race hazard, where it will be true only briefly between polls, so will be missed.
* So keep track of the last time that all jobs were completed for each project, i.e. indexing has finished, and return that as the last indexed time for the active project.