### PR TITLE
Bump lisp version for --last-indexed rc option

### DIFF
--- a/src/rtags.el
+++ b/src/rtags.el
@@ -70,7 +70,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Constants
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(defconst rtags-protocol-version 124)
+(defconst rtags-protocol-version 125)
 (defconst rtags-package-version "2.18")
 (defconst rtags-popup-available (require 'popup nil t))
 (defconst rtags-supported-major-modes '(c-mode c++-mode objc-mode) "Major modes RTags supports.")


### PR DESCRIPTION
Keep version consistent with new options.

Addresses github issue https://github.com/Andersbakken/rtags/issues/1183 introduced by commit 6dc572b5985b1624de86776e5e48335b33d73c85