### PR TITLE
Fixed an issue with code completion.

### DIFF
--- a/src/CompletionThread.cpp
+++ b/src/CompletionThread.cpp
@@ -305,7 +305,7 @@ void CompletionThread::process(Request *request)
         completionFlags |= CXCodeComplete_IncludeMacros;
 
     CXCodeCompleteResults *results = clang_codeCompleteAt(cache->translationUnit->unit, sourceFile.constData(),
-                                                          request->location.line(), request->location.column() - request->prefix.length(),
+                                                          request->location.line(), request->location.column(),
                                                           &unsaved, unsaved.Length ? 1 : 0, completionFlags);
     completeTime = cache->codeCompleteTime = sw.restart();
     LOG() << "Generated" << (results ? results->NumResults : 0) << "completions for" << request->location << (results ? "successfully" : "unsuccessfully") << "in" << completeTime << "ms";


### PR DESCRIPTION
Try code completion after `foo` in the following example:

```
int foobar();

int main() {

	foo

	return 0;
}
```
This causes RTags to do a code completion at location 5:2 with prefix 'foo', which is correct. But later in the call to clang the column location is subtracted with the length of the prefix, which gives an incorrect location and therefor no code completions are possible.
