### PR TITLE
Convert cc_prefix.sh and gcc-rtags-hook.sh to POSIX sh

### DIFF
--- a/bin/cc_prefix.sh
+++ b/bin/cc_prefix.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 
-[ -z "$RTAGS_DISABLED" ] && [ -x "$(which rc)" ] && rc --silent --compile "$@" &
+[ -z "$RTAGS_DISABLED" ] && [ -x "$(command -v rc)" ] && rc --silent --compile "$@" &
 [ "$RTAGS_RMAKE" ] && exit 1
 compiler="$1"
 shift

--- a/bin/gcc-rtags-hook.sh
+++ b/bin/gcc-rtags-hook.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 
-if [ -z "$RTAGS_DISABLED" ] && [ -x "$(which rc)" ]; then
+if [ -z "$RTAGS_DISABLED" ] && [ -x "$(command -v rc)" ]; then
     rc --silent --compile "$ICECC_CXX" "$@" &
 fi
 


### PR DESCRIPTION
Hi,

Are you open to having the shell scripts conform to POSIX?  The changes to these two scripts are minor.  If you are receptive to this, I will convert gcc-rtags-wrapper.sh as well.

My motivation for doing this is to make installation easier for systems that do not include bash by default, like *BSD.

Thanks for rtags,

Joseph