### PR TITLE
Fix cmake argument in Readme.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -31,7 +31,7 @@ Build RTags
 #+BEGIN_SRC sh
 git clone --recursive https://github.com/Andersbakken/rtags.git
 cd rtags
-cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 .
+cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ..
 make
 #+END_SRC
 


### PR DESCRIPTION
In the TLDR session, previously, the  instruction 
`cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 .`
led to an error due to absent CMakeLists.txt file. 

Corrected to `cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ..`