### PR TITLE
Use correct environment variable for config path

### DIFF
--- a/src/CommandLineParser.h
+++ b/src/CommandLineParser.h
@@ -95,7 +95,7 @@ ParseStatus parse(int argc, char **argv,
         bool norc = false;
         Path rcfile = Path::home() + "." + app + "rc";
         if (!rcfile.exists()) {
-            const char * configPath = getenv("XDG_CONFIG_DIR");
+            const char * configPath = getenv("XDG_CONFIG_HOME");
             rcfile = configPath ? configPath : Path::home() + ".config";
             rcfile += "/rtags/";
             rcfile.mkdir(Path::Recursive);


### PR DESCRIPTION
XDG Base Directory Specification specifies XDG_CONFIG_HOME instead of
XDG_CONFIG_DIR.