### PR TITLE
Do not print an error message for a null symbol that is a file symbol

### DIFF
--- a/src/QueryJob.cpp
+++ b/src/QueryJob.cpp
@@ -136,7 +136,9 @@ bool QueryJob::locationToString(Location location,
         int idx;
         Symbol symbol = project()->findSymbol(location, &idx);
         if (symbol.isNull()) {
-            error() << "Somehow can't find" << location << "in symbols";
+            if (!(symbol.flags & Symbol::FileSymbol)) {
+                error() << "Somehow can't find" << location << "in symbols";
+            }
         } else {
             if (!mKindFilters.filter(symbol))
                 return false;


### PR DESCRIPTION
File symbols are expected to be null.