### PR TITLE
Completion should not show NotAccessible items

### DIFF
--- a/src/CompletionThread.cpp
+++ b/src/CompletionThread.cpp
@@ -343,7 +343,7 @@ void CompletionThread::process(Request *request)
                 case CXAvailability_Deprecated:
                     break;
                 case CXAvailability_NotAccessible:
-                    break;
+                    continue;
                 case CXAvailability_NotAvailable: // protected members are erroneously flagged as NotAvailable in clang 3.6
                     continue;
                 }

--- a/tests/automated/Completion/expectation.json
+++ b/tests/automated/Completion/expectation.json
@@ -4,12 +4,12 @@
       "rc-command": [ "--code-complete-at", "{0}/main.cpp:12:15",
                       "--synchronous-completions"],
 
-      "expectation": [ "get int get() CXXMethod Foo",
-                       "validate void validate(int) CXXMethod  Foo",
-                       "Foo Foo:: ClassDecl Foo",
-                       "operator= Foo & operator=(const Foo &) CXXMethod Foo",
-                       "operator= Foo & operator=(Foo &&) CXXMethod Foo",
-                       "~Foo void ~Foo() CXXDestructor Foo",
+      "expectation": [ " get int get() CXXMethod  Foo ",
+                       " validate void validate(int) CXXMethod  Foo ",
+                       " Foo Foo:: ClassDecl  Foo ",
+                       " operator= Foo & operator=(const Foo &) CXXMethod  Foo ",
+                       " operator= Foo & operator=(Foo &&) CXXMethod  Foo ",
+                       " ~Foo void ~Foo() CXXDestructor  Foo ",
                        ""] },
 
     { "name": "completion should not show not accessible/private items",
@@ -17,10 +17,10 @@
       "rc-command": [ "--code-complete-at", "{0}/main.cpp:20:7",
                       "--synchronous-completions"],
 
-      "expectation": [ "get int get() CXXMethod Foo",
-                       "Foo Foo:: ClassDecl Foo",
-                       "operator= Foo & operator=(const Foo &) CXXMethod Foo",
-                       "operator= Foo & operator=(Foo &&) CXXMethod Foo",
-                       "~Foo void ~Foo() CXXDestructor Foo",
+      "expectation": [ " get int get() CXXMethod  Foo ",
+                       " Foo Foo:: ClassDecl  Foo ",
+                       " operator= Foo & operator=(const Foo &) CXXMethod  Foo ",
+                       " operator= Foo & operator=(Foo &&) CXXMethod  Foo ",
+                       " ~Foo void ~Foo() CXXDestructor  Foo ",
                        ""] }
 ]

--- a/tests/automated/Completion/expectation.json
+++ b/tests/automated/Completion/expectation.json
@@ -1,0 +1,26 @@
+[
+    { "name": "completion should show accessible items",
+
+      "rc-command": [ "--code-complete-at", "{0}/main.cpp:12:15",
+                      "--synchronous-completions"],
+
+      "expectation": [ "get int get() CXXMethod Foo",
+                       "validate void validate(int) CXXMethod  Foo",
+                       "Foo Foo:: ClassDecl Foo",
+                       "operator= Foo & operator=(const Foo &) CXXMethod Foo",
+                       "operator= Foo & operator=(Foo &&) CXXMethod Foo",
+                       "~Foo void ~Foo() CXXDestructor Foo",
+                       ""] },
+
+    { "name": "completion should not show not accessible/private items",
+
+      "rc-command": [ "--code-complete-at", "{0}/main.cpp:20:7",
+                      "--synchronous-completions"],
+
+      "expectation": [ "get int get() CXXMethod Foo",
+                       "Foo Foo:: ClassDecl Foo",
+                       "operator= Foo & operator=(const Foo &) CXXMethod Foo",
+                       "operator= Foo & operator=(Foo &&) CXXMethod Foo",
+                       "~Foo void ~Foo() CXXDestructor Foo",
+                       ""] }
+]

--- a/tests/automated/Completion/main.cpp
+++ b/tests/automated/Completion/main.cpp
@@ -1,0 +1,21 @@
+class Foo
+{
+public:
+    int get()
+    {
+        return 12;
+    }
+
+private:
+    void validate(int)
+    {
+        this->
+    }
+};
+
+
+int main()
+{
+    Foo f;
+    f.
+}

--- a/tests/automated/test_runner.py
+++ b/tests/automated/test_runner.py
@@ -114,7 +114,7 @@ def run_completion(test_dir, rc_command, expected):
     size = len(outputs)
     assert_that(size, equal_to(len(expected)))
 
-    for i in xrange (0, size):
+    for i in range (0, size):
         assert_that(non_empty_split(outputs[i].strip(), " "),
                     equal_to(non_empty_split(expected[i].strip(), " ")))
 

--- a/tests/automated/test_runner.py
+++ b/tests/automated/test_runner.py
@@ -20,7 +20,7 @@ import sys
 import json
 import time
 import subprocess as sp
-from hamcrest import assert_that, has_length, has_item, empty, is_not, equal_to
+from hamcrest import assert_that, has_length, has_item, empty, is_not, equal_to, contains_inanyorder
 
 sys.dont_write_bytecode = True
 os.environ["PYTHONDONTWRITEBYTECODE"] = "1"
@@ -105,18 +105,12 @@ def run_parse(test_dir, rc_command, expected):
     assert_that(output, is_not(empty()))
     assert_that(output.split(" "), has_item(expected.format(test_dir + "/")))
 
-def non_empty_split(s, delim=None):
-    return [x for x in s.split(delim) if x]
-
 def run_completion(test_dir, rc_command, expected):
     outputs = run_rc([c.format(test_dir) for c in rc_command]).split("\n")
 
-    size = len(outputs)
-    assert_that(size, equal_to(len(expected)))
-
-    for i in range (0, size):
-        assert_that(non_empty_split(outputs[i].strip(), " "),
-                    equal_to(non_empty_split(expected[i].strip(), " ")))
+    assert_that(len(outputs), equal_to(len(expected)))
+    for output in outputs:
+        assert_that(expected, has_item(output))
 
 def run(test_dir, rc_command, expected, test_type):
     """


### PR DESCRIPTION
Hi,

lately I have started using auto completion from rtags, but I realized that the output contain too much informations. In my daily work I need to operate with classes that contain a lot of private members/functions so it is inconvenient for me. 

According to [libclang doc](https://clang.llvm.org/doxygen/group__CINDEX.html#gada331ea0195e952c8f181ecf15e83d71) the **CXAvailability_NotAccessible** means that the entity is available, but not accessible. Any use of it will be an error, so I changed the code to behave the same as for CXAvailability_NotAvailable.

What do you think about it? Are changes fine to be merged or something need to be changed?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/andersbakken/rtags/1248)
<!-- Reviewable:end -->
