### PR TITLE
make rtags-install work with tramp locations

### DIFF
--- a/src/rtags.el
+++ b/src/rtags.el
@@ -5351,9 +5351,9 @@ the user enter missing field manually."
                                                                 "make\n"
                                                                 "exit $?\n")
         (rtags--write-region (point-min) (point-max) "install-rtags.sh"))
-      (switch-to-buffer (rtags-get-buffer "*RTags install*"))
+      (switch-to-buffer (rtags-get-buffer rtags-install-buffer-name))
       (setq buffer-read-only t)
-      (setq rtags-install-process (start-process "*RTags install*" (current-buffer) "bash" (concat dir "/install-rtags.sh")))
+      (setq rtags-install-process (start-file-process rtags-install-buffer-name (current-buffer) "bash" (rtags-untrampify (concat dir "/install-rtags.sh"))))
       (set-process-sentinel rtags-install-process 'rtags-install-process-sentinel)
       (set-process-filter rtags-install-process 'rtags-install-process-filter))))
 


### PR DESCRIPTION
when one wants rtags be used with distant (tramp) sanbox, it is required to install binary part of rtags (rc/rdm/rp/helper scripts) there. (emacs part is NOT needed). The only step then is to run the following:
  `M-x rtags-install: REMOTE-LOCATION`
  for example:
  `M-x rtags-install: "/scp:user@host:/home/user/.local/bin"`

  The change below allows for that.
