### PR TITLE
silenced unecessary memaccess warning

### DIFF
--- a/src/FileMap.h
+++ b/src/FileMap.h
@@ -328,6 +328,8 @@ private:
     const char *valuesSegment() const { return mPointer + mValuesOffset; }
     const char *keysSegment() const { return mPointer + (sizeof(uint32_t) * 2); }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
     template <typename T>
     inline T read(const char *base, uint32_t index) const
     {
@@ -343,6 +345,7 @@ private:
         deserializer >> t;
         return t;
     }
+#pragma GCC diagnostic pop
 
     const char *mPointer;
     uint32_t mSize;


### PR DESCRIPTION
I don't see any other way to implement the deserialization, so I guess it makes sense to quiet the warning here.  Do you agree?

With this change, the only warning left is the possible truncation of 4 characters in the snprintf statement 
    /home/stg/repos/rtags/src/rdm.cpp:847:72: warning: ‘.tmp’ directive output may be truncated writing 4 bytes into a region of size between 1 and 4096 [-Wformat-truncation=]

I think this could be silenced by checking the return value of snprintf, and if negative printing a message to  stderr.  Then we could put in a better solution if the error ever occurs.  What do you think?