### PR TITLE
Do not remove characters from the display name of FieldDecl symbols

### DIFF
--- a/src/Symbol.cpp
+++ b/src/Symbol.cpp
@@ -233,15 +233,6 @@ String Symbol::displayName() const
         if (end != -1)
             return symbolName.left(end);
         break; }
-    case CXCursor_FieldDecl: {
-        int colon = symbolName.indexOf(':');
-        if (colon != -1) {
-            const int end = colon + 2;
-            while (colon > 0 && RTags::isSymbol(symbolName.at(colon - 1)))
-                --colon;
-            return symbolName.left(colon + 1) + symbolName.mid(end);
-        }
-        break; }
     default:
         break;
     }


### PR DESCRIPTION
What was the purpose of this code? Why apply it only to FieldDecl symbols? It seems somewhat arbitrary to someone who's not familiar with the history.

This code had a different effect depending on the symbol's type.

For example:

int ClassName::fieldName --> int CfieldName
std::basic_string<...> ClassName::fieldName --> sbasic_string<...> ClassName::fieldName
