### PR TITLE
Consider all other unsaved files when code completing a given file

### DIFF
--- a/src/CompletionThread.h
+++ b/src/CompletionThread.h
@@ -51,9 +51,9 @@ public:
     };
     bool isCached(const std::shared_ptr<Project> &project, uint32_t fileId) const;
     void completeAt(Source &&source, Location location, Flags<Flag> flags, int max,
-                    String &&unsaved, const String &prefix,
+                    const UnsavedFiles &unsavedFiles, const String &prefix,
                     const std::shared_ptr<Connection> &conn);
-    void prepare(Source &&source, String &&unsaved);
+    void prepare(Source &&source, const UnsavedFiles &unsavedFiles);
     Source findSource(const Set<uint32_t> &deps) const;
     void reparse(const std::shared_ptr<Project> &project, uint32_t fileId);
     void stop();
@@ -77,7 +77,8 @@ private:
         Location location;
         Flags<Flag> flags;
         int max;
-        String unsaved, prefix;
+        UnsavedFiles unsavedFiles;
+        String prefix;
         std::shared_ptr<Connection> conn;
     };
     LinkedList<Request*> mPending;
@@ -131,7 +132,7 @@ private:
             : lastModified(0), parseTime(0), reparseTime(0), codeCompleteTime(0), completions(0), next(0), prev(0)
         {}
         std::shared_ptr<RTags::TranslationUnit> translationUnit;
-        String unsaved;
+        UnsavedFiles unsavedFiles;
         uint64_t lastModified;
         uint64_t parseTime, reparseTime, codeCompleteTime; // ms
         size_t completions;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -2328,7 +2328,7 @@ void Server::codeCompleteAt(const std::shared_ptr<QueryMessage> &query, const st
         flags |= CompletionThread::IncludeMacros;
     if (query->flags() & QueryMessage::CodeCompleteNoWait)
         flags |= CompletionThread::NoWait;
-    mCompletionThread->completeAt(std::move(source), loc, flags, query->max(), query->unsavedFiles().value(loc.path()), query->codeCompletePrefix(), c);
+    mCompletionThread->completeAt(std::move(source), loc, flags, query->max(), query->unsavedFiles(), query->codeCompletePrefix(), c);
 }
 
 void Server::dumpJobs(const std::shared_ptr<Connection> &conn)
@@ -2572,7 +2572,7 @@ void Server::prepareCompletion(const std::shared_ptr<QueryMessage> &query, uint3
             }
 
             if (!source.isNull())
-                mCompletionThread->prepare(std::move(source), query->unsavedFiles().value(Location::path(fileId)));
+                mCompletionThread->prepare(std::move(source), query->unsavedFiles());
         }
     }
 }


### PR DESCRIPTION
This change should not be merged in its current form. I'd like to have a code review to improve it.

If the file being code-completed depends on other unsaved header files,
then those other headers also need to be reindexed. Otherwise, when
the file being code-completed is reindexed, the last saved versions of
those header dependencies will be used.

This change is a work in progress. It introduces some inefficiencies
that should be optimized:
- It passes all unsaved files to the completion thread, rather than only
those that the file being code-completed depends on.
- It copies and compares UnsavedFiles (std::unordered_map) objects
several times.