### PR TITLE
Output #include/break/continue/return symbol targets for JSON and Elisp

### DIFF
--- a/src/Symbol.cpp
+++ b/src/Symbol.cpp
@@ -269,8 +269,10 @@ Value Symbol::toValue(const std::shared_ptr<Project> &project,
                 (*val)[ctxKey] = loc.context(locationToStringFlags);
             }
         };
-        if (!symbol.isNull()) {
+        if (!symbol.location.isNull()) {
             formatLocation(symbol.location, "location", "context");
+        }
+        if (!symbol.isNull()) {
             if (symbol.argumentUsage.index != String::npos) {
                 formatLocation(symbol.argumentUsage.invocation, "invocation", "invocationContext", 0, "invocationcontext");
                 if (filterPiece("invokedfunction"))


### PR DESCRIPTION
The targets of #include/break/continue/return symbols do not have a
valid CXCursorKind,  and so Symbol::isNull() returns true for them. But
these targets do have a valid location.

This change enables outputting the locations of these targets when using
--symbol-info-include-targets --json/--elisp.