### PR TITLE
Consider unsaved files when reindexing to recover from #include errors

### DIFF
--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -802,7 +802,7 @@ void Project::onJobFinished(const std::shared_ptr<IndexerJob> &job, const std::s
 
     Set<uint32_t> visited = msg->visitedFiles();
     updateFixIts(visited, msg->fixIts());
-    updateDependencies(fileId, msg);
+    updateDependencies(fileId, msg, job->unsavedFiles);
     if (success) {
         forEachSources([&msg, fileId](Sources &sources) -> VisitResult {
                 // error() << "finished with" << Location::path(fileId) << sources.contains(fileId) << msg->parseTime();
@@ -1091,7 +1091,7 @@ void Project::removeDependencies(uint32_t fileId)
     }
 }
 
-void Project::updateDependencies(uint32_t fileId, const std::shared_ptr<IndexDataMessage> &msg)
+void Project::updateDependencies(uint32_t fileId, const std::shared_ptr<IndexDataMessage> &msg, const UnsavedFiles &unsavedFiles)
 {
     static_cast<void>(fileId);
     const bool prune = !(msg->flags() & (IndexDataMessage::InclusionError|IndexDataMessage::ParseFailure));
@@ -1163,7 +1163,7 @@ void Project::updateDependencies(uint32_t fileId, const std::shared_ptr<IndexDat
         // }
         SimpleDirty simple;
         simple.init(shared_from_this(), dirty);
-        startDirtyJobs(&simple, IndexerJob::Dirty);
+        startDirtyJobs(&simple, IndexerJob::Dirty, unsavedFiles);
     }
     // for (auto node : mDependencies) {
     //     for (auto inc : node.second->includes) {

--- a/src/Project.h
+++ b/src/Project.h
@@ -318,7 +318,7 @@ private:
     };
     bool validate(uint32_t fileId, ValidateMode mode, String *error = 0) const;
     void removeDependencies(uint32_t fileId);
-    void updateDependencies(uint32_t fileId, const std::shared_ptr<IndexDataMessage> &msg);
+    void updateDependencies(uint32_t fileId, const std::shared_ptr<IndexDataMessage> &msg, const UnsavedFiles &unsavedFiles);
     void loadFailed(uint32_t fileId);
     void updateFixIts(const Set<uint32_t> &visited, FixIts &fixIts);
     int startDirtyJobs(Dirty *dirty,


### PR DESCRIPTION
If unsaved files are not passed to an indexing job for those same files,
then the last saved versions of the files are used. This change fixes the
following issue caused by that behavior:

1. An #include error is introduced into a file, and the file is saved
and reindexed.
2. The #include error is removed, and the file is reindexed again with
--reindex --unsaved-file, but not saved again.
3. After the indexing job has finished, updating dependencies causes the
file to be reindexed yet again (because the #include error has been
removed).
4. The last saved version of the file (still containing the #include
error) is used when updating dependencies.