### PR TITLE
Do not explicitly validate the project while it's still indexing

### DIFF
--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -400,6 +400,13 @@ bool Project::init()
 
 void Project::check(CheckMode checkMode)
 {
+    if ((checkMode == Check_Explicit) && isIndexing()) {
+        // it's not safe to validate the project while it's still loading
+        // try again in 5 minutes
+        mCheckTimer.restart(CheckPeriodicTimeout);
+        return;
+    }
+
     const Server::Options &options = Server::instance()->options();
     bool needsSave = false;
     std::unique_ptr<ComplexDirty> dirty;

--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -39,7 +39,13 @@
 #include "Server.h"
 #include "RTagsVersion.h"
 
-enum { DirtyTimeout = 100, CheckExplicitTimeout = 500, CheckPeriodicTimeout = 60 * 60000 };
+enum
+{
+    DirtyTimeout         = 100,
+    CheckExplicitTimeout = 500,
+    CheckRetryTimeout    = 5  * 60 * 1000,
+    CheckPeriodicTimeout = 60 * 60 * 1000
+};
 
 class Dirty
 {
@@ -403,7 +409,7 @@ void Project::check(CheckMode checkMode)
     if ((checkMode == Check_Explicit) && isIndexing()) {
         // it's not safe to validate the project while it's still loading
         // try again in 5 minutes
-        mCheckTimer.restart(CheckPeriodicTimeout);
+        mCheckTimer.restart(CheckRetryTimeout);
         return;
     }
 
@@ -495,7 +501,7 @@ void Project::check(CheckMode checkMode)
         simple.init(shared_from_this(), missingFileMaps);
         startDirtyJobs(&simple, IndexerJob::Dirty);
     }
-    mCheckTimer.restart(CheckPeriodicTimeout); // always checking every 5 minutes
+    mCheckTimer.restart(CheckPeriodicTimeout); // always checking every 1 hour
 }
 
 bool Project::match(const Match &p, bool *indexed) const


### PR DESCRIPTION
The explicit project check is invoked while switching the current
project and through the check timer. If the project is validated while
it's still loading, then some dependencies may be incorrectly removed,
because they haven't been fully indexed yet.

The issue can be reproduced by loading two projects with
--load-compile-commands, and then using --project to switch back and
forth between the projects while they're loading. Project::validate()
will output the error message: "Error during validation: \<file\> doesn't
exist".