### PR TITLE
Add print include path

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -168,6 +168,7 @@ set(RTAGS_SOURCES
     CompilerManager.cpp
     CompletionThread.cpp
     DependenciesJob.cpp
+    IncludePathJob.cpp
     FileManager.cpp
     FindFileJob.cpp
     FindSymbolsJob.cpp

--- a/src/IncludePathJob.cpp
+++ b/src/IncludePathJob.cpp
@@ -1,0 +1,68 @@
+/* This file is part of RTags (http://rtags.net).
+
+   RTags is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   RTags is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with RTags.  If not, see <http://www.gnu.org/licenses/>. */
+
+#include "IncludePathJob.h"
+
+#include "Project.h"
+#include "RTags.h"
+#include "Server.h"
+
+IncludePathJob::IncludePathJob(const Location loc, const std::shared_ptr<QueryMessage> &query, const std::shared_ptr<Project> &project)
+    : QueryJob(query, project, QuietJob), location(loc)
+{
+}
+
+int IncludePathJob::execute()
+{
+    int idx = 0;
+    Symbol symbol = project()->findSymbol(location, &idx);
+    if (symbol.isNull()) {
+        return 1;
+    }
+
+    // if you invoke a destructor explicitly there's a typeref on the class
+    // name. This finds the destructor instead.
+    if ((symbol.kind == CXCursor_TypeRef || symbol.kind == CXCursor_TemplateRef) && idx > 0) {
+        auto symbols = project()->openSymbols(location.fileId());
+        if (!symbols || !symbols->count())
+            return 1;
+        const Symbol prev = symbols->valueAt(idx - 1);
+        if (prev.kind == CXCursor_MemberRefExpr
+                && prev.location.column() == symbol.location.column() - 1
+                && prev.location.line() == symbol.location.line()
+                && prev.symbolName.contains("~")) {
+            symbol = prev;
+        }
+    }
+
+    if (queryFlags() & QueryMessage::TargetUsrs) {
+        const Set<String> usrs = project()->findTargetUsrs(location);
+        for (const String &usr : usrs) {
+            write(usr);
+        }
+        return 0;
+    }
+
+    auto targets = RTags::sortTargets(project()->findTargets(symbol));
+
+    String allTargetPath;
+    for (const auto &target : targets) {
+        allTargetPath += project()->dumpIncludePath(location, target) + "\n";
+    }
+
+    // debug() << "IncludePathJob::allTargetPath: " << allTargetPath;
+    write(allTargetPath);
+    return 0;
+}

--- a/src/IncludePathJob.h
+++ b/src/IncludePathJob.h
@@ -1,0 +1,33 @@
+/* This file is part of RTags (http://rtags.net).
+
+   RTags is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   RTags is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with RTags.  If not, see <http://www.gnu.org/licenses/>. */
+
+#ifndef IncludePathJob_h
+#define IncludePathJob_h
+
+#include "QueryJob.h"
+
+class Project;
+class QueryMessage;
+class IncludePathJob : public QueryJob
+{
+    public:
+        IncludePathJob(const Location loc, const std::shared_ptr<QueryMessage> &query, const std::shared_ptr<Project> &project);
+    protected:
+        virtual int execute() override;
+    private:
+        const Location location;
+};
+
+#endif

--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -2032,6 +2032,39 @@ static String addDeps(const Dependencies &deps)
     return ret;
 }
 
+String Project::dumpIncludePath(const Location loc, const Symbol symbol) const
+{
+    String allPath;
+
+    Set<DependencyNode*> seen;
+    DependencyNode *depNode = mDependencies.value(loc.fileId());
+    if (depNode) {
+        int startDepth = 1;
+
+        String path;
+        std::function<void(DependencyNode *, int)> process = [&](DependencyNode *n, int depth) {
+            String nodePath = String::format<1024>("%s%s", String(depth * 2, ' ').constData(), Location::path(n->fileId).constData());
+            path += nodePath;
+
+            if (seen.insert(n) && !n->includes.isEmpty()) {
+                if (Location::path(n->fileId) == symbol.location.path()) {
+                    allPath += path + "\n";
+
+                    path.clear();
+                    return;
+                }
+                for (const auto &includeNode : n->includes) {
+                    process(includeNode.second, depth + 1);
+                }
+            }
+            path.remove(nodePath);
+        };
+        process(depNode, startDepth);
+    }
+
+    return allPath;
+}
+
 String Project::dumpDependencies(uint32_t fileId, const List<String> &args, Flags<QueryMessage::Flag> flags) const
 {
     String ret;

--- a/src/Project.h
+++ b/src/Project.h
@@ -137,6 +137,7 @@ public:
     String dumpDependencies(uint32_t fileId,
                             const List<String> &args = List<String>(),
                             Flags<QueryMessage::Flag> flags = Flags<QueryMessage::Flag>()) const;
+    String dumpIncludePath(const Location loc, const Symbol symbol) const;
     const Hash<uint32_t, DependencyNode*> &dependencies() const { return mDependencies; }
     DependencyNode *dependencyNode(uint32_t fileId) const { return mDependencies.value(fileId); }
 

--- a/src/QueryMessage.h
+++ b/src/QueryMessage.h
@@ -74,7 +74,8 @@ public:
 #ifdef RTAGS_HAS_LUA
         VisitAST,
 #endif
-        Tokens
+        Tokens,
+        IncludePath,
     };
 
     enum Flag {

--- a/src/RClient.cpp
+++ b/src/RClient.cpp
@@ -183,6 +183,7 @@ std::initializer_list<CommandLineParser::Option<RClient::OptionType> > opts = {
 #endif
     { RClient::TokensIncludeSymbols, "tokens-include-symbols", 0, CommandLineParser::NoValue, "Include symbols for tokens." },
     { RClient::NoRealPath, "no-realpath", 0, CommandLineParser::NoValue, "Don't resolve paths using realpath(3)." },
+    { RClient::IncludePath, "include-path", 0, CommandLineParser::Required, "Dump include path for symbol." },
     { RClient::None, String(), 0, CommandLineParser::NoValue, 0 }
 };
 
@@ -1309,6 +1310,14 @@ CommandLineParser::ParseStatus RClient::parse(size_t argc, char **argv)
             }
             mVisitASTScripts.push_back(std::move(code));
 #endif
+            break; }
+        case IncludePath: {
+            String encoded = Location::encode(value);
+            if (encoded.isEmpty()) {
+              return { String::format<1024>("include path Can't resolve argument %s", value.constData()), CommandLineParser::Parse_Error };
+            }
+
+            addQuery(QueryMessage::IncludePath, std::move(encoded));
             break; }
         }
         return { String(), CommandLineParser::Parse_Exec };

--- a/src/RClient.h
+++ b/src/RClient.h
@@ -159,7 +159,8 @@ public:
         Wait,
         WildcardSymbolNames,
         XML,
-        NumOptions
+        NumOptions,
+        IncludePath,
     };
 
     RClient();

--- a/src/Server.h
+++ b/src/Server.h
@@ -173,6 +173,7 @@ private:
     void codeCompleteAt(const std::shared_ptr<QueryMessage> &query, const std::shared_ptr<Connection> &conn);
     void symbolInfo(const std::shared_ptr<QueryMessage> &query, const std::shared_ptr<Connection> &conn);
     void dependencies(const std::shared_ptr<QueryMessage> &query, const std::shared_ptr<Connection> &conn);
+    void includePath(const std::shared_ptr<QueryMessage> &query, const std::shared_ptr<Connection> &conn);
     void startClangThread(const std::shared_ptr<QueryMessage> &query, const std::shared_ptr<Connection> &conn);
     void dumpFileMaps(const std::shared_ptr<QueryMessage> &query, const std::shared_ptr<Connection> &conn);
     void diagnose(const std::shared_ptr<QueryMessage> &query, const std::shared_ptr<Connection> &conn);

--- a/src/rtags.el
+++ b/src/rtags.el
@@ -1682,6 +1682,18 @@ instead of file from `current-buffer'.
       (rtags-call-rc :path fn "--dependencies" fn args (unless rtags-print-filenames-relative "-K"))
       (rtags-mode))))
 
+(defun rtags-print-include-path (&optional buffer)
+  "Print include path of the current symbol in cursor."
+
+  (interactive "P")
+  (let ((dep-buffer (rtags-get-buffer))
+        (arg (rtags-current-location)))
+    (rtags-delete-rtags-windows)
+    (rtags-location-stack-push)
+    (rtags-switch-to-buffer dep-buffer)
+    (rtags-call-rc "--include-path" arg)
+    (rtags-mode)))
+
 (defun rtags-find-dead-functions (&optional prefix buffer)
   "Print information about uncalled functions in buffer."
   (interactive "P")


### PR DESCRIPTION
Add job to print the include path of symbol(function). It would be helpful to clean up the include headers with this function.