### PR TITLE
Ensure that the project path always has a trailing slash

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -645,7 +645,7 @@ void Server::handleIndexMessage(const std::shared_ptr<IndexMessage> &message, co
     if (conn)
         conn->finish(ret ? 0 : 1);
     if (ret) {
-        auto proj = addProject(data.project);
+        auto proj = addProject(data.project.ensureTrailingSlash());
         if (proj) {
             assert(proj);
             proj->processParseData(std::move(data));


### PR DESCRIPTION
This change fixes restoring projects when rdm is stopped and restarted
with the --no-realpath option. It also causes project paths to be
displayed consistently whether or not --no-realpath is specified.

The underlying issue is that Path::resolve() adds a trailing slash when
realpath is enabled, but does not when realpath is disabled.