### PR TITLE
Add missing git submodule update

### DIFF
--- a/README.org
+++ b/README.org
@@ -31,6 +31,7 @@ Build RTags
 #+BEGIN_SRC sh
 git clone --recursive https://github.com/Andersbakken/rtags.git
 cd rtags
+git submodule update
 cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 .
 make
 #+END_SRC


### PR DESCRIPTION
If I don't run `git submodule update`, the cmake configuration will try to fail finding the `rct.cmake` file:

```
CMake Error at src/CMakeLists.txt:129 (include):
  include could not find load file:

    rct/rct.cmake
```