### PR TITLE
tests: Wait 0.1s after "rtags-rc" -w for rtags-rdm to become ready

### DIFF
--- a/tests/automated/test_runner.py
+++ b/tests/automated/test_runner.py
@@ -154,6 +154,7 @@ def setup_rdm(test_dir, test_files):
     for _ in range(10):
         try:
             run_rc(["-w"])
+            time.sleep(0.1)
             break
         except sp.CalledProcessError:
             time.sleep(0.01)


### PR DESCRIPTION
Rtags-rdm seems to not be ready immediately and this causes failures in Ubuntu CI infrastructure.