### PR TITLE
Fix DatabaseVersion 

### DIFF
--- a/src/ClangIndexer.cpp
+++ b/src/ClangIndexer.cpp
@@ -84,7 +84,7 @@ ClangIndexer::ClangIndexer(Mode mode)
       mVisitFileResponseMessageVisit(0), mParseDuration(0), mVisitDuration(0), mBlocked(0),
       mAllowed(0), mIndexed(1), mVisitFileTimeout(0), mIndexDataMessageTimeout(0),
       mFileIdsQueried(0), mFileIdsQueriedTime(0), mCursorsVisited(0), mLogFile(nullptr),
-      mConnection(Connection::create(RClient::NumOptions)), mUnionRecursion(false),
+      mConnection(Connection::create(RTags::DatabaseVersion)), mUnionRecursion(false),
       mFromCache(false), mInTemplateFunction(0)
 {
     mConnection->newMessage().connect(std::bind(&ClangIndexer::onMessage, this,

--- a/src/RClient.cpp
+++ b/src/RClient.cpp
@@ -30,6 +30,7 @@
 #include "rct/OnDestruction.h"
 #include "RTags.h"
 #include "RTagsLogOutput.h"
+#include "RTagsVersion.h"
 
 #define DEFAULT_CONNECT_TIMEOUT 1000
 #define XSTR(s) #s
@@ -371,7 +372,7 @@ void RClient::exec()
     loop->init(EventLoop::MainEventLoop);
 
     const int commandCount = mCommands.size();
-    std::shared_ptr<Connection> connection = Connection::create(NumOptions);
+    std::shared_ptr<Connection> connection = Connection::create(RTags::DatabaseVersion);
     connection->newMessage().connect(std::bind(&RClient::onNewMessage, this,
                                                std::placeholders::_1, std::placeholders::_2));
     connection->finished().connect(std::bind([](){ EventLoop::eventLoop()->quit(); }));
@@ -641,8 +642,8 @@ CommandLineParser::ParseStatus RClient::parse(size_t argc, char **argv)
             return { String(), CommandLineParser::Parse_Ok }; }
         case VerifyVersion: {
             const int version = strtoul(value.constData(), nullptr, 10);
-            if (version != NumOptions) {
-                fprintf(stdout, "Protocol version mismatch got: %d expected: %d \n", version, NumOptions);
+            if (version != RTags::DatabaseVersion) {
+                fprintf(stdout, "Protocol version mismatch got: %d expected: %d \n", version, RTags::DatabaseVersion);
                 mExitCode = RTags::ProtocolFailure;
                 return { String(), CommandLineParser::Parse_Error };
             }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -248,7 +248,7 @@ bool Server::initServers()
             mTcpServer.reset();
             if (!i) {
                 enum { Timeout = 1000 };
-                std::shared_ptr<Connection> connection = Connection::create(RClient::NumOptions);
+                std::shared_ptr<Connection> connection = Connection::create(RTags::DatabaseVersion);
                 if (connection->connectTcp("127.0.0.1", mOptions.tcpPort, Timeout)) {
                     connection->send(QuitMessage());
                     connection->disconnected().connect(std::bind([](){ EventLoop::eventLoop()->quit(); }));
@@ -312,7 +312,7 @@ bool Server::initServers()
 
     if (Path::exists(mOptions.socketFile)) {
         enum { Timeout = 1000 };
-        std::shared_ptr<Connection> connection = Connection::create(RClient::NumOptions);
+        std::shared_ptr<Connection> connection = Connection::create(RTags::DatabaseVersion);
         if (connection->connectUnix(mOptions.socketFile, Timeout)) {
             connection->send(QuitMessage());
             connection->disconnected().connect(std::bind([](){ EventLoop::eventLoop()->quit(); }));
@@ -356,7 +356,7 @@ void Server::onNewConnection(SocketServer *server)
         if (!client) {
             break;
         }
-        std::shared_ptr<Connection> conn = Connection::create(client, RClient::NumOptions);
+        std::shared_ptr<Connection> conn = Connection::create(client, RTags::DatabaseVersion);
         if (mOptions.maxSocketWriteBufferSize) {
             client->setMaxWriteBufferSize(mOptions.maxSocketWriteBufferSize);
         }
@@ -2404,7 +2404,7 @@ class TestConnection
 {
 public:
     TestConnection(const Path &workingDirectory)
-        : mConnection(Connection::create(RClient::NumOptions)),
+        : mConnection(Connection::create(RTags::DatabaseVersion)),
           mIsFinished(false), mWorkingDirectory(workingDirectory)
     {
         mConnection->aboutToSend().connect([this](const std::shared_ptr<Connection> &, const Message *message) {

--- a/src/rtags.el
+++ b/src/rtags.el
@@ -66,7 +66,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Constants
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(defconst rtags-protocol-version 129)
+(defconst rtags-protocol-version 130)
 (defconst rtags-package-version "2.37")
 (defconst rtags-popup-available (require 'popup nil t))
 (defconst rtags-supported-major-modes '(c-mode c++-mode objc-mode) "Major modes RTags supports.")


### PR DESCRIPTION
Hi, I was trying to figure out the reasons to the recent movements forth and back between versions 129 and 130, as well for the disagreement between v129 in `src/rtags.el` and v130 in  `CMakeLists.txt`.

It looks like an enum value  `RClient::NumOptions` that by a chance happen to be  equal to 129 is used in some places where the explicit `RTags::DatabaseVersion` seems to be more suitable.