### PR TITLE
Fix issue with rtags-xref

### DIFF
--- a/src/rtags-xref.el
+++ b/src/rtags-xref.el
@@ -48,7 +48,7 @@
 (require 'xref)
 (require 'rtags)
 
-(cl-defgeneric rtags-xref-backend-identifier-at-point ((_backend (eql rtags)))
+(cl-defmethod xref-backend-identifier-at-point ((_backend (eql rtags)))
   "Return the relevant identifier at point."
   (let ((thing (thing-at-point 'symbol)))
     (and thing (propertize (substring-no-properties thing)


### PR DESCRIPTION
Hi,

Had an issue with `rtags-xref`, where `xref-find-definitions` would not trigger an `-f` but an `-F` `rc` invocation.

This change fixes it for me. I'm not at all an expert with Emacs or elisp, but this fix seems sensible though.

Cheers,

-Freek