### PR TITLE
Add when argument to define-obsolete-function-alias

### DIFF
--- a/src/rtags.el
+++ b/src/rtags.el
@@ -4689,7 +4689,7 @@ definition."
        (and rtags-autostart-diagnostics (rtags-diagnostics))
        (set-process-query-on-exit-flag rtags-rdm-process nil)
        (set-process-sentinel rtags-rdm-process 'rtags-sentinel)))))
-(define-obsolete-function-alias 'rtags-start-process-maybe 'rtags-start-process-unless-running)
+(define-obsolete-function-alias 'rtags-start-process-maybe 'rtags-start-process-unless-running "v2.2")
 
 (defun rtags-sentinel (process _event)
   "Watch the activity of RTags process (rdm)."


### PR DESCRIPTION
The `when` has become mandatory since https://emba.gnu.org/emacs/emacs/-/commit/32c6732d16385f242b1109517f25e9aefd6caa5c (credit to @zflat).

Fortunately the emacs-24.3 (the lowest supported version according to package), has already support for the `when` parameter.

I've used `v2.2` as this is the tag that follows commit that added the obsole call (dbf1ca3b2518d43f8c1b897d71126cfd132ef30b).

fixes #1408