### PR TITLE
Fix rtags completion over tramp with unsaved buffer for remote file

### DIFF
--- a/src/rtags.el
+++ b/src/rtags.el
@@ -1309,8 +1309,8 @@ to only call this when `rtags-socket-address' is defined.
           (when path-filter-regex
             (push "-Z" arguments)))
         (when (and unsaved (rtags-buffer-file-name unsaved))
-          (setq tempfile (make-temp-file "/tmp/"))
-          (push (format "--unsaved-file=%s:%s" (rtags-untrampify (rtags-buffer-file-name unsaved)) tempfile) arguments)
+          (setq tempfile (make-nearby-temp-file "rtags"))
+          (push (format "--unsaved-file=%s:%s" (rtags-untrampify (rtags-buffer-file-name unsaved)) (rtags-untrampify tempfile)) arguments)
           (with-current-buffer unsaved
             (save-restriction
               (widen)


### PR DESCRIPTION
Just wanted to say rtags is awesome and thanks for making my life easier. 

To work with my remote project, I followed this PR https://github.com/Andersbakken/rtags/pull/546 which was pretty straight forward (it was very helpful so should we add the details to the wiki?). Next, I added company-rtags for completion as described in the [wiki#code-completion-in-emacs](https://github.com/Andersbakken/rtags/wiki/Usage#code-completion-in-emacs). However, it would fail with a company async timeout. After quite a bit of digging (and learning :sweat_smile: ), I found that rtags elisp code was sending the unsaved buffer as a temp file but this temp file was being created locally. Just a few small changes and everything was working like a charm.

Fixes:
1. Use the tramp aware function [make-nearby-temp-file](https://www.gnu.org/software/emacs/manual/html_node/elisp/Unique-File-Names.html#index-make_002dnearby_002dtemp_002dfile) to create the temp file on the remote host (if default-directory is remote).
2. Change the path prefix to a relative path as absolute forces it to always be a local file.
3. Change the path prefix to be unique to rtags as suggested by the documentation for make-temp-file ([See "To prevent conflicts..."](https://www.gnu.org/software/emacs/manual/html_node/elisp/Unique-File-Names.html#index-make_002dtemp_002dfile)).
4. Use rtags-untrampify on the temp file name so that we always pass the local file name to rc.

Let me know if there is anything else I can do to make this PR approved.
